### PR TITLE
Add params to toggle use of vertex attribute arrays or WEBGL_multi_draw extension

### DIFF
--- a/Animometer/tests/3d/webgl.html
+++ b/Animometer/tests/3d/webgl.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <canvas id="stage"></canvas>
-    <script id="vertex" type="x-shader/x-glsl">
+    <script id="vertex-with-uniforms" type="x-shader/x-glsl">
 attribute vec4 position;
 attribute vec4 color;
 
@@ -16,6 +16,43 @@ uniform float offsetX;
 uniform float offsetY;
 uniform float scalar;
 uniform float scalarOffset;
+
+varying vec4 v_color;
+
+void main() {
+
+    float fade = mod(scalarOffset + time * scalar / 10.0, 1.0);
+
+    if (fade < 0.5) {
+        fade = fade * 2.0;
+    } else {
+        fade = (1.0 - fade) * 2.0;
+    }
+
+    float xpos = position.x * scale;
+    float ypos = position.y * scale;
+
+    float angle = 3.14159 * 2.0 * fade;
+    float xrot = xpos * cos(angle) - ypos * sin(angle);
+    float yrot = xpos * sin(angle) + ypos * cos(angle);
+
+    xpos = xrot + offsetX;
+    ypos = yrot + offsetY;
+
+    v_color = vec4(fade, 1.0 - fade, 0.0, 1.0) + color;
+    gl_Position = vec4(xpos, ypos, 0.0, 1.0);
+}
+    </script>
+    <script id="vertex-with-attributes" type="x-shader/x-glsl">
+attribute vec4 position;
+attribute vec4 color;
+attribute float scale;
+attribute float offsetX;
+attribute float offsetY;
+attribute float scalar;
+attribute float scalarOffset;
+
+uniform float time;
 
 varying vec4 v_color;
 


### PR DESCRIPTION
This change adds params to use the `WEBGL_multi_draw` extension to draw all of the Animometer triangles.
It additionally adds params to using vertex attribute arrays instead of uniforms because the addition of vertex attribute arrays to the test is necessary to test with `WEBGL_multi_draw`.
These flags are configured by changing the URL parameters `use_attributes` and `multi_draw`.