### PR TITLE
Fix Animometer test to use struct of vec4s

### DIFF
--- a/Animometer/tests/3d/resources/webgl.js
+++ b/Animometer/tests/3d/resources/webgl.js
@@ -63,7 +63,9 @@ WebGLStage = Utilities.createSubclass(Stage,
             // The source code for the shader is extracted from the <script> element above.
             if (use_ubos) {
                 let source = this._getFunctionSource("vertex-with-ubos");
-                this._maxUniformArraySize = Math.floor(gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE) / (8 * 4));
+                this._maxUniformArraySize = Math.floor(
+                    gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE) /
+                    (8 * Float32Array.BYTES_PER_ELEMENT));
                 source = source.replace('MAX_ARRAY_SIZE', this._maxUniformArraySize);
                 gl.shaderSource(vertexShader, source);
             } else if (use_attributes) {

--- a/Animometer/tests/3d/webgl.html
+++ b/Animometer/tests/3d/webgl.html
@@ -52,14 +52,8 @@ in vec4 color;
 uniform float time;
 
 struct DrawInfo {
-  float scale;
-  float offsetX;
-  float offsetY;
-  float scalar;
-  float scalarOffset;
-  float pad0;
-  float pad1;
-  float pad2;
+  vec4 data0;
+  vec4 data1;
 };
 
 layout(std140) uniform DrawData { DrawInfo values[MAX_ARRAY_SIZE]; } data;
@@ -67,11 +61,11 @@ layout(std140) uniform DrawData { DrawInfo values[MAX_ARRAY_SIZE]; } data;
 out vec4 v_color;
 
 void main() {
-    float scale        = data.values[gl_DrawID].scale;
-    float offsetX      = data.values[gl_DrawID].offsetX;
-    float offsetY      = data.values[gl_DrawID].offsetY;
-    float scalar       = data.values[gl_DrawID].scalar;
-    float scalarOffset = data.values[gl_DrawID].scalarOffset;
+    float scale        = data.values[gl_DrawID].data0.x;
+    float offsetX      = data.values[gl_DrawID].data0.y;
+    float offsetY      = data.values[gl_DrawID].data0.z;
+    float scalar       = data.values[gl_DrawID].data0.w;
+    float scalarOffset = data.values[gl_DrawID].data1.x;
 
     float fade = mod(scalarOffset + time * scalar / 10.0, 1.0);
 


### PR DESCRIPTION
With layout(std140), for an array of scalars or vectors, the base
alignment and array stride is rounded up to the base alignment of
a vec4.