### PR TITLE
Add webgl-indexed-instanced.html test for profiling base vertex feature

### DIFF
--- a/Animometer/tests/3d/resources/webgl-indexed-instanced.js
+++ b/Animometer/tests/3d/resources/webgl-indexed-instanced.js
@@ -54,6 +54,11 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._multi_draw = this._params.use_multi_draw && gl.getExtension("WEBGL_multi_draw");
             this._draw_base_vertex_base_instance = !this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
             this._multi_draw_base_vertex_base_instance = this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance");
+            
+            // console.log(this._multi_draw);
+            // console.log(this._draw_base_vertex_base_instance);
+            // console.log(this._multi_draw_base_vertex_base_instance);
+            
             // if (this._params.use_base_vertex_base_instance && !this._multi_draw_base_vertex_base_instance) {
             if ( this._params.use_base_vertex_base_instance && !(this._draw_base_vertex_base_instance || this._multi_draw_base_vertex_base_instance) ) {
                 console.warn("Disabling use_base_vertex_base_instance. Extension not available.");
@@ -77,6 +82,9 @@ WebGLStage = Utilities.createSubclass(Stage,
                 this._params[flag] = true;
             }
 
+            console.log(this._params.use_base_vertex_base_instance);
+            console.log(this._params.use_multi_draw);
+
             // this._numTriangles = 0;
             // this._bufferSize = 0;
 
@@ -86,7 +94,8 @@ WebGLStage = Utilities.createSubclass(Stage,
             // this._drawListUpdateFrameInterval = 50;
             // this._drawListUpdateFrameInterval = 20;
             // this._drawListUpdateFrameInterval = 10;
-            this._drawListUpdateFrameInterval = 5;
+            // this._drawListUpdateFrameInterval = 5;
+            this._drawListUpdateFrameInterval = 1;
             this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
             this._numDrawingObjects = 0;
 
@@ -257,13 +266,13 @@ WebGLStage = Utilities.createSubclass(Stage,
             // this._bufferSize = this._numTriangles;
 
             this._drawListSet.push([...Array(this._numTriangles).keys()]);
-            // this._drawListSet.push([10, 20, 30, 1000]);    // all wrong (except 0)
+            this._drawListSet.push([10, 20, 30, 1000]);
             // // this._drawListSet.push([0]);
             // // this._drawListSet.push([10]);
             // this._drawListSet.push([2,3,4,5,6,7,8,9,10]);    // mbvbi = raw, m has wrong shape(id offset)
-            // this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
-            // this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
-            // this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
+            this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
+            this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
+            this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
             // // console.log(this._drawListSet);
 
             // this._drawListSet.push([0]);

--- a/Animometer/tests/3d/resources/webgl-indexed-instanced.js
+++ b/Animometer/tests/3d/resources/webgl-indexed-instanced.js
@@ -12,7 +12,6 @@ WebGLStage = Utilities.createSubclass(Stage,
     {
 
         initialize: function(count, benchmark, options)
-        // initialize: function(benchmark, options)
         {
             Stage.prototype.initialize.call(this, benchmark, options);
 
@@ -35,7 +34,7 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._numTriangles = Math.max(count, 0);
             this._use_element_index_uint = false;
             console.log("numTriangles: " + this._numTriangles);
-            // if (this._numTriangles * 3 > (1 << 16)) {
+            if (this._numTriangles * 3 > (1 << 16)) {
                 console.log("use gl.UNSIGNED_INT");
                 // unsigned int index is always available in WebGL 2
                 this._use_element_index_uint = true;
@@ -44,10 +43,10 @@ WebGLStage = Utilities.createSubclass(Stage,
                 // if (!this._use_element_index_uint) {
                 //     console.warn("OES_element_index_uint is not available, too many vertices");
                 // }
-            // } else {
-            //     console.log("use gl.UNSIGNED_SHORT");
-            //     this._use_element_index_uint = false;
-            // }
+            } else {
+                console.log("use gl.UNSIGNED_SHORT");
+                this._use_element_index_uint = false;
+            }
             this._elements_type = this._use_element_index_uint ? gl.UNSIGNED_INT : gl.UNSIGNED_SHORT;
             this._elements_typed_array_class = this._use_element_index_uint ? Uint32Array : Uint16Array;
 
@@ -55,11 +54,6 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._draw_base_vertex_base_instance = !this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
             this._multi_draw_base_vertex_base_instance = this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance");
             
-            // console.log(this._multi_draw);
-            // console.log(this._draw_base_vertex_base_instance);
-            // console.log(this._multi_draw_base_vertex_base_instance);
-            
-            // if (this._params.use_base_vertex_base_instance && !this._multi_draw_base_vertex_base_instance) {
             if ( this._params.use_base_vertex_base_instance && !(this._draw_base_vertex_base_instance || this._multi_draw_base_vertex_base_instance) ) {
                 console.warn("Disabling use_base_vertex_base_instance. Extension not available.");
                 this._params.use_base_vertex_base_instance = false;
@@ -82,12 +76,6 @@ WebGLStage = Utilities.createSubclass(Stage,
                 this._params[flag] = true;
             }
 
-            console.log(this._params.use_base_vertex_base_instance);
-            console.log(this._params.use_multi_draw);
-
-            // this._numTriangles = 0;
-            // this._bufferSize = 0;
-
             // storing object id (order in the index buffer) that needs rendering for current frame
             this._drawList = [];
             // this._drawListRatio = 0.5;
@@ -99,23 +87,18 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
             this._numDrawingObjects = 0;
 
-            // temp test
             this._drawListSet = [];
             this._curDrawListId = 0;
-            // this._drawListSet.push(Array())
-            // for (let i = 0; i < 5; i++) {
-            //     let list = [];
-            //     this._drawListSet[i] = list;
-            // }
+
+            this._drawListSet.push([...Array(this._numTriangles).keys()]);
+            this._drawListSet.push([10, 20, 30, 1000]);
+            this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
+            this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
+            this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
 
             var use_ubos = this._params.use_ubos;
             var use_attributes = this._params.use_attributes;
 
-            // if (!this._bufferSize)
-            //     this._bufferSize = 128;
-
-            // while (this._numTriangles > this._bufferSize)
-            //     this._bufferSize *= 4;
             if (use_ubos) {
                 if (!this._bufferSize)
                     this._bufferSize = 128;
@@ -231,14 +214,7 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             this._indexData = new this._elements_typed_array_class([
                 0, 1, 2
-                // 3, 4, 5
-                // 6, 7, 8
             ]);
-            // this._indexData = new Uint16Array([
-            //     0, 1, 2
-            //     // 3, 4, 5
-            //     // 6, 7, 8
-            // ]);
 
             this._resetIfNecessary();
         },
@@ -252,40 +228,6 @@ WebGLStage = Utilities.createSubclass(Stage,
         {
             var gl = this._gl;
 
-
-            // if (this._numTriangles <= this._bufferSize)
-            //     return;
-
-            // if (!this._bufferSize)
-            //     this._bufferSize = 128;
-
-            // while (this._numTriangles > this._bufferSize)
-            //     this._bufferSize *= 4;
-
-            // temp
-            // this._bufferSize = this._numTriangles;
-
-            this._drawListSet.push([...Array(this._numTriangles).keys()]);
-            this._drawListSet.push([10, 20, 30, 1000]);
-            // // this._drawListSet.push([0]);
-            // // this._drawListSet.push([10]);
-            // this._drawListSet.push([2,3,4,5,6,7,8,9,10]);    // mbvbi = raw, m has wrong shape(id offset)
-            this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
-            this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
-            this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
-            // // console.log(this._drawListSet);
-
-            // this._drawListSet.push([0]);
-            // this._drawListSet.push([1]);
-            // this._drawListSet.push([2]);
-            // this._drawListSet.push([3]);
-            // this._drawListSet.push([1000]);
-            // this._drawListSet.push([0,1,2,3,1000]);
-
-            // this._drawListSet.push([0,1,2,3,4]);
-            // this._drawListSet.push([2,3,4,5,6,7,8,9,10]);
-            // this._drawListSet.push([10,20,30,40,50,1000]);
-
             var use_attributes = this._params.use_attributes;
             var use_ubos = this._params.use_ubos;
             var use_multi_draw = this._params.use_multi_draw;
@@ -293,12 +235,9 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             var positionData = new Float32Array(this._bufferSize * this._positionData.length);
             var colorData = new Float32Array(this._bufferSize * this._colorData.length);
-            // var indexData = new Uint16Array(this._bufferSize * this._indexData.length);
             var indexData = new this._elements_typed_array_class(this._bufferSize * this._indexData.length);
 
             for (let i = 0; i < this._bufferSize; ++i) {
-                // positionData.set(this._positionData, i * this._positionData.length);
-
                 let offset = i * this._positionData.length;
                 for (let j = 0; j < this._positionData.length; j+=4) {
                     // each position is vec4
@@ -311,12 +250,13 @@ WebGLStage = Utilities.createSubclass(Stage,
                 }
 
                 colorData.set(this._colorData, i * this._colorData.length);
-                // indexData.set(this._indexData, i * this._indexData.length);
             }
 
             this._multi_draw_counts = new Int32Array(this._bufferSize);
             this._multi_draw_offsets = new Int32Array(this._bufferSize);
             this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+
+            let sizeof_elements = (this._elements_type === gl.UNSIGNED_INT ? 4 : 2);
 
             if (use_base_vertex_base_instance) {
                 // actually only use base vertex
@@ -324,48 +264,34 @@ WebGLStage = Utilities.createSubclass(Stage,
                 this._multi_draw_instance_counts.fill(1);
                 this._multi_draw_base_vertices = new Int32Array(this._bufferSize);
                 this._multi_draw_base_vertices_dynamic = new Int32Array(this._bufferSize);
-                // this._multi_draw_base_vertices.fill(0);
                 this._multi_draw_base_instances = new Uint32Array(this._bufferSize);
                 this._multi_draw_base_instances.fill(0);
 
                 for (let i = 0; i < this._bufferSize; ++i) {
                     this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
 
-                    // in bytes (UNSIGNED_INT), for index buffer
-                    this._multi_draw_offsets[i] = i * 4 * 3;
-                    // // in bytes (UNSIGNED_SHORT), for index buffer
-                    // this._multi_draw_offsets[i] = i * 2 * 3;
+                    this._multi_draw_offsets[i] = i * sizeof_elements * 3;
                 }
 
                 // this._multi_draw_offsets.fill(0);
             } else {
                 for (let i = 0; i < this._bufferSize; ++i) {
-                    // this._multi_draw_firsts[i] = i * 3;
-
                     // in bytes (UNSIGNED_INT), for index buffer
-                    this._multi_draw_offsets[i] = i * 4 * 3;
-                    // // in bytes (UNSIGNED_SHORT), for index buffer
-                    // this._multi_draw_offsets[i] = i * 2 * 3;
-
-                    // this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
-                }
+                    this._multi_draw_offsets[i] = i * sizeof_elements * 3;
+               }
             }
             
             // Currently all our testing geometries are triangles. But they don't have to be
             this._multi_draw_counts.fill(3);
 
             if (!use_base_vertex_base_instance) {
-                // indexData = new Uint16Array(this._bufferSize * this._indexData.length);
-                // this._currentIndexData = new Uint16Array(this._bufferSize * this._indexData.length);
                 this._currentIndexData = new this._elements_typed_array_class(this._bufferSize * this._indexData.length);
                 this._originalIndexData = indexData;
                 
                 // Indices data here are added with extra offset
                 for (let i = 0; i < this._bufferSize; ++i) {
-                    // indexData.set(this._indexData, i * this._indexData.length);
-                    
+                    // asume all triangles
                     let o = i * 3;  // assume this._indexData.length = 3;
-                    // let indexOffset = this._draw;
                     indexData[o] = this._indexData[0] + o;
                     indexData[o + 1] = this._indexData[1] + o;
                     indexData[o + 2] = this._indexData[2] + o;
@@ -373,16 +299,11 @@ WebGLStage = Utilities.createSubclass(Stage,
             }
             else
             {
-                // // This is temporary usage which assume all primitives having same indexData (triangle)
-                // indexData = this._indexData;
-
                 // Directly copy the original indexData into indexBuffer
                 for (let i = 0; i < this._bufferSize; ++i) {
                     indexData.set(this._indexData, i * this._indexData.length);
                 }
             }
-
-            // console.log(this._bufferSize);
 
             if (use_ubos) {
                 this._transformData = new Float32Array(this._bufferSize * 8);
@@ -400,12 +321,6 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._transformData[i * 8 + 4] = scalarOffset;
                 }
 
-                // console.log(this._transformData[1000 * 8 + 0]);
-                // console.log(this._transformData[1000 * 8 + 1]);
-                // console.log(this._transformData[1000 * 8 + 2]);
-                // console.log(this._transformData[1000 * 8 + 3]);
-                // console.log(this._transformData[1000 * 8 + 4]);
-
                 const uniformBufferCount = Math.ceil(this._bufferSize / this._maxUniformArraySize);
                 this._uniformBuffers = new Array(uniformBufferCount);
                 for (let i = 0; i < uniformBufferCount; ++i) {
@@ -421,12 +336,8 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             } else if (use_attributes) {
                 console.log('use_attributes setup');
-                // console.log(this._bufferSize);
-                // console.log(this._numTriangles);
                 this._transformData = new Float32Array(this._bufferSize * 5 * 3);
                 for (let i = 0; i < this._bufferSize; ++i) {
-                // this._transformData = new Float32Array(this._numTriangles * 5 * 3);
-                // for (let i = 0; i < this._numTriangles; ++i) {
                     var scale = Stage.random(0.2, 0.4);
                     var offsetX = Stage.random(-0.9, 0.9);
                     var offsetY = Stage.random(-0.9, 0.9);
@@ -454,8 +365,6 @@ WebGLStage = Utilities.createSubclass(Stage,
             } else {
                 this._uniformData = new Float32Array(this._bufferSize * 6);
                 for (let i = 0; i < this._bufferSize; ++i) {
-                // this._uniformData = new Float32Array(this._numTriangles * 6);
-                // for (let i = 0; i < this._numTriangles; ++i) {
                     this._uniformData[i * 6 + 0] = Stage.random(0.2, 0.4);
                     this._uniformData[i * 6 + 1] = 0;
                     this._uniformData[i * 6 + 2] = Stage.random(-0.9, 0.9);
@@ -463,13 +372,6 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._uniformData[i * 6 + 4] = Stage.random(0.5, 2);
                     this._uniformData[i * 6 + 5] = Stage.random(0, 10);
                 }
-
-                // console.log(this._uniformData[1000 * 6 + 0]);
-                // // console.log(this._uniformData[1000 * 6 + 1]);
-                // console.log(this._uniformData[1000 * 6 + 2]);
-                // console.log(this._uniformData[1000 * 6 + 3]);
-                // console.log(this._uniformData[1000 * 6 + 4]);
-                // console.log(this._uniformData[1000 * 6 + 5]);
             }
 
             this._positionBuffer = gl.createBuffer();
@@ -484,34 +386,11 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             this._indexBuffer = gl.createBuffer();
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
-            gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, gl.DYNAMIC_DRAW);
-            // gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, use_base_vertex_base_instance ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
-
+            // when use_base_vertex_base_instance we don't need to update index buffer data
+            gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, use_base_vertex_base_instance ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
 
             this._updateDrawList(gl);
-
-            // console.log(this._multi_draw_offsets);
-            // console.log(this._multi_draw_base_vertices);
-            // console.log('------------reset----------');
         },
-
-        // tune: function(count)
-        // {
-        //     if (!count)
-        //         return;
-
-        //     // this._numTriangles += count;
-        //     this._numTriangles = count;
-        //     this._numTriangles = Math.max(this._numTriangles, 0);
-
-        //     this._resetIfNecessary();
-        // },
-
-        // _updateCurrentIndexData: function()
-        // {
-        //     // used by multi draw without base vertex base instance option
-
-        // },
 
         animate: function(timeDelta)
         {
@@ -527,23 +406,15 @@ WebGLStage = Utilities.createSubclass(Stage,
                 this._updateDrawList(gl);
             }
 
-            // this._drawList = this._drawListSet[this._curDrawListId];
-            // this._numDrawingObjects = this._drawList.length;
-
-
             if (!this._startTime)
                 this._startTime = Stage.dateCounterValue(1000);
             var elapsedTime = Stage.dateCounterValue(1000) - this._startTime;
-
-            // // tmp test static
-            // elapsedTime = 0;
 
             if (this._params.use_multi_draw) {
                 gl.uniform1f(this._uTime, elapsedTime);
                 if (this._params.use_ubos) {
                     let remainingDrawCount = this._numDrawingObjects;
 
-                    // for (let chunk = 0; chunk < Math.ceil(this._numTriangles / this._maxUniformArraySize); chunk++) {
                     for (let chunk = 0, count = Math.ceil(this._numDrawingObjects / this._maxUniformArraySize); chunk < count; chunk++) {
                         
                         gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, this._uniformBuffers[chunk]);
@@ -552,36 +423,16 @@ WebGLStage = Utilities.createSubclass(Stage,
                             this._multi_draw_base_vertex_base_instance.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
                                 gl.TRIANGLES,
                                 this._multi_draw_counts, chunk * this._maxUniformArraySize,
-                                // gl.UNSIGNED_SHORT,
                                 this._elements_type,
-                                // this._multi_draw_offsets, chunk * this._maxUniformArraySize,
                                 this._multi_draw_offsets_dynamic, chunk * this._maxUniformArraySize,
                                 this._multi_draw_instance_counts, chunk * this._maxUniformArraySize,
-                                // this._multi_draw_base_vertices, 0,
                                 this._multi_draw_base_vertices_dynamic, chunk * this._maxUniformArraySize,
                                 this._multi_draw_base_instances, chunk * this._maxUniformArraySize,
                                 Math.min(this._maxUniformArraySize, remainingDrawCount));
-                                // 1);
-
-                                // console.log(this._multi_draw_offsets_dynamic[this._drawList[0]]);
-
-                            // remainingDrawCount -= this._maxUniformArraySize;
-
-                            // this._multi_draw_base_vertex_base_instance.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
-                            //     gl.TRIANGLES,
-                            //     this._multi_draw_counts, chunk * this._maxUniformArraySize,
-                            //     gl.UNSIGNED_SHORT,
-                            //     this._multi_draw_offsets, chunk * this._maxUniformArraySize,
-                            //     this._multi_draw_instance_counts, 0,
-                            //     this._multi_draw_base_vertices, 0,
-                            //     // this._multi_draw_base_vertices_dynamic, 0,
-                            //     this._multi_draw_base_instances, 0,
-                            //     this._numDrawingObjects);
                         } else {
                             this._multi_draw.multiDrawElementsWEBGL(
                                 gl.TRIANGLES,
                                 this._multi_draw_counts, chunk * this._maxUniformArraySize,
-                                // gl.UNSIGNED_SHORT,
                                 this._elements_type,
                                 this._multi_draw_offsets, chunk * this._maxUniformArraySize,
                                 Math.min(this._maxUniformArraySize, remainingDrawCount));
@@ -590,12 +441,6 @@ WebGLStage = Utilities.createSubclass(Stage,
                         remainingDrawCount -= this._maxUniformArraySize;
                     }
                 } else {
-                    // this._multi_draw.multiDrawElementsWEBGL(
-                    //     gl.TRIANGLES,
-                    //     this._multi_draw_counts, chunk * this._maxUniformArraySize,
-                    //     gl.UNSIGNED_SHORT,
-                    //     this._multi_draw_offsets, chunk * this._maxUniformArraySize,
-                    //     this._numTriangles);
 
                     // multi_draw
                     // use_attributes
@@ -604,21 +449,16 @@ WebGLStage = Utilities.createSubclass(Stage,
                         this._multi_draw_base_vertex_base_instance.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
                             gl.TRIANGLES,
                             this._multi_draw_counts, 0,
-                            // gl.UNSIGNED_SHORT,
                             this._elements_type,
-                            // this._multi_draw_offsets, chunk * this._maxUniformArraySize,
                             this._multi_draw_offsets_dynamic, 0,
                             this._multi_draw_instance_counts, 0,
-                            // this._multi_draw_base_vertices, 0,
                             this._multi_draw_base_vertices_dynamic, 0,
                             this._multi_draw_base_instances, 0,
                             this._numDrawingObjects);
-                            // 1);
                     } else {
                         this._multi_draw.multiDrawElementsWEBGL(
                             gl.TRIANGLES,
                             this._multi_draw_counts, 0,
-                            // gl.UNSIGNED_SHORT,
                             this._elements_type,
                             this._multi_draw_offsets, 0,
                             this._numDrawingObjects);
@@ -637,8 +477,6 @@ WebGLStage = Utilities.createSubclass(Stage,
                         this._draw_base_vertex_base_instance.drawElementsInstancedBaseVertexBaseInstanceWEBGL(
                             gl.TRIANGLES,
                             this._multi_draw_counts[oid],
-                            // 3,  // temp
-                            // gl.UNSIGNED_SHORT,
                             this._elements_type,
                             this._multi_draw_offsets[oid],
                             1,
@@ -649,16 +487,13 @@ WebGLStage = Utilities.createSubclass(Stage,
                     
                 } else {
                     for (let i = 0; i < this._numDrawingObjects; ++i) {
-                    // for (let i = 21800; i < this._numDrawingObjects; ++i) {
                         let oid = this._drawList[i];
-                        // gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, this._multi_draw_offsets[oid]);
                         gl.drawElements(gl.TRIANGLES, 3, this._elements_type, this._multi_draw_offsets[oid]);
                     }
                 }
 
                 
             } else {
-                // for (let i = 0; i < this._numTriangles; ++i) {
                 for (let i = 0; i < this._numDrawingObjects; ++i) {
                     let oid = this._drawList[i];
                     this._uniformData[oid * 6 + 1] = elapsedTime;
@@ -671,9 +506,6 @@ WebGLStage = Utilities.createSubclass(Stage,
                     gl.uniform1f(this._uScalar, this._uniformData[uniformDataOffset++]);
                     gl.uniform1f(this._uScalarOffset, this._uniformData[uniformDataOffset++]);
 
-                    // gl.drawArrays(gl.TRIANGLES, 0, 3);
-                    // console.log("ffff");
-                    // gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, this._multi_draw_offsets[oid]);
                     gl.drawElements(gl.TRIANGLES, 3, this._elements_type, this._multi_draw_offsets[oid]);
                 }
             }
@@ -681,14 +513,8 @@ WebGLStage = Utilities.createSubclass(Stage,
 
         _updateDrawList: function(gl)
         {
-
             this._drawList = this._drawListSet[this._curDrawListId];
             this._numDrawingObjects = this._drawList.length;
-
-            // console.log('updateDrawList');
-
-            let needsUpdateAttributes = false;
-
 
             if (this._params.use_base_vertex_base_instance && this._params.use_multi_draw) {
                 let id;
@@ -698,68 +524,29 @@ WebGLStage = Utilities.createSubclass(Stage,
 
                     this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
                 }
-                // console.log(this._multi_draw_offsets_dynamic[0]);
-                // console.log(this._multi_draw_base_vertices_dynamic[0]);
             }
             // update this._multi_draw_counts data etc.
             else if (this._params.use_multi_draw) {
-                // this._multi_draw_counts; // currently all triangle reamin at 3    
 
                 for (let i = 0; i < this._numDrawingObjects; i++) {
                     id = this._drawList[i]; // drawing object id
                     // update index data and upload
                     let o = i * 3;
                     let oid = id * 3;   // assume triangle, offset of it's first index in originalIndexData
-                    //
                     this._currentIndexData[o] = this._originalIndexData[oid];
                     this._currentIndexData[o + 1] = this._originalIndexData[oid + 1];
                     this._currentIndexData[o + 2] = this._originalIndexData[oid + 2];
                 }
                 gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0, this._currentIndexData, 0, this._numDrawingObjects * 3);
 
-                needsUpdateAttributes = true;
             }
             else
             {
                 // not using multi_draw
                 // no need to update draw list data
-
-                // console.log(this._multi_draw_offsets[this._drawList[0]]);
-                needsUpdateAttributes = true;
             }
 
-            // // console.log(this._drawList);
-            // if (needsUpdateAttributes) {
-            //     for (let i = 0; i < this._numDrawingObjects; i++) {
-            //         id = this._drawList[i]; // drawing object id
-            //         // update index data and upload
-
-            //         // 
-            //         // each drawing object has 5 transform float data;
-            //         let o = i * 3 * 5;
-
-            //         let scale = this._transformData[o];
-            //         let offsetX = Stage.random(-0.9, 0.9);
-            //         let offsetY = Stage.random(-0.9, 0.9);
-            //         let scalar = Stage.random(0.5, 2);
-            //         let scalarOffset = Stage.random(0, 10);
-
-            //         for (let j = 0; j < 3; ++j) {
-            //             this._transformData[i * 3 * 5 + j * 5 + 0] = scale;
-            //             this._transformData[i * 3 * 5 + j * 5 + 1] = offsetX;
-            //             this._transformData[i * 3 * 5 + j * 5 + 2] = offsetY;
-            //             this._transformData[i * 3 * 5 + j * 5 + 3] = scalar;
-            //             this._transformData[i * 3 * 5 + j * 5 + 4] = scalarOffset;
-            //         }
-            //     }
-            // }
-            
-        },
-
-        // complexity: function()
-        // {
-        //     return this._numTriangles;
-        // }
+        }
     }
 );
 

--- a/Animometer/tests/3d/resources/webgl-indexed-instanced.js
+++ b/Animometer/tests/3d/resources/webgl-indexed-instanced.js
@@ -63,9 +63,9 @@ WebGLStage = Utilities.createSubclass(Stage,
             // storing object id (order in the index buffer) that needs rendering for current frame
             this._drawList = [];
             // this._drawListRatio = 0.5;
-            // this._drawListUpdateFrameInterval = 50;
+            this._drawListUpdateFrameInterval = 50;
             // this._drawListUpdateFrameInterval = 20;
-            this._drawListUpdateFrameInterval = 10;
+            // this._drawListUpdateFrameInterval = 10;
             // this._drawListUpdateFrameInterval = 5;
             this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
             this._numDrawingObjects = 0;
@@ -188,22 +188,6 @@ WebGLStage = Utilities.createSubclass(Stage,
                 // 3, 4, 5
                 // 6, 7, 8
             ]);
-
-            // if (!use_attributes && !use_ubos) {
-            //     this._positionBuffer = gl.createBuffer();
-            //     gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
-            //     gl.bufferData(gl.ARRAY_BUFFER, this._positionData, gl.STATIC_DRAW);
-
-            //     this._colorBuffer = gl.createBuffer();
-            //     gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
-            //     gl.bufferData(gl.ARRAY_BUFFER, this._colorData, gl.STATIC_DRAW);
-
-            //     this._indexBuffer = gl.createBuffer();
-            //     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
-            //     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this._indexData, gl.STATIC_DRAW);
-            // }
-
-            // this._resetIfNecessary();
         },
 
         _getFunctionSource: function(id)
@@ -223,15 +207,23 @@ WebGLStage = Utilities.createSubclass(Stage,
             while (this._numTriangles > this._bufferSize)
                 this._bufferSize *= 4;
 
-            this._drawListSet.push([...Array(this._numTriangles).keys()]);
-            this._drawListSet.push([0, 10, 20, 30, 1000]);    // all wrong (except 0)
+            // // this._drawListSet.push([...Array(this._numTriangles).keys()]);
+            // this._drawListSet.push([10, 20, 30, 1000]);    // all wrong (except 0)
+            // // this._drawListSet.push([0]);
+            // // this._drawListSet.push([10]);
+            // this._drawListSet.push([2,3,4,5,6,7,8,9,10]);    // mbvbi = raw, m has wrong shape(id offset)
+            // // this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
+            // // this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
+            // // this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
+            // // console.log(this._drawListSet);
+
             // this._drawListSet.push([0]);
-            // this._drawListSet.push([10]);
-            // this._drawListSet.push([0,1,2,3,4,5,6,7,8,9,10]);    // mbvbi = raw, m has wrong shape(id offset)
-            this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
-            this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
-            this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
-            // console.log(this._drawListSet);
+            // this._drawListSet.push([1]);
+            // this._drawListSet.push([2]);
+            // this._drawListSet.push([3]);
+            // this._drawListSet.push([1000]);
+            // this._drawListSet.push([0,1,2,3,1000]);
+            this._drawListSet.push([0,1,2,3,4]);
 
             var use_attributes = this._params.use_attributes;
             var use_ubos = this._params.use_ubos;
@@ -260,47 +252,9 @@ WebGLStage = Utilities.createSubclass(Stage,
                 // indexData.set(this._indexData, i * this._indexData.length);
             }
 
-            // if (use_multi_draw || use_base_vertex_base_instance) {
-            //     // this._multi_draw_firsts = new Int32Array(this._bufferSize);
-            //     this._multi_draw_counts = new Int32Array(this._bufferSize);
-            //     this._multi_draw_offsets = new Int32Array(this._bufferSize);
-
-            //     // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
-
-            //     if (use_base_vertex_base_instance) {
-            //         // actually only use base vertex
-            //         this._multi_draw_instance_counts = new Int32Array(this._bufferSize);
-            //         this._multi_draw_instance_counts.fill(1);
-            //         this._multi_draw_base_vertices = new Int32Array(this._bufferSize);
-            //         this._multi_draw_base_vertices_dynamic = new Int32Array(this._bufferSize);
-            //         // this._multi_draw_base_vertices.fill(0);
-            //         this._multi_draw_base_instances = new Uint32Array(this._bufferSize);
-            //         this._multi_draw_base_instances.fill(0);
-
-            //         for (let i = 0; i < this._bufferSize; ++i) {
-            //             this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
-            //         }
-
-            //         this._multi_draw_offsets.fill(0);
-            //     } else {
-            //         this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
-            //         for (let i = 0; i < this._bufferSize; ++i) {
-            //             // this._multi_draw_firsts[i] = i * 3;
-            //             this._multi_draw_offsets[i] = i * 2 * 3;    // in bytes, for index buffer
-    
-            //             // this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
-            //         }
-            //     }
-
-                
-            //     this._multi_draw_counts.fill(3);
-            // }
-
-            // this._multi_draw_firsts = new Int32Array(this._bufferSize);
             this._multi_draw_counts = new Int32Array(this._bufferSize);
             this._multi_draw_offsets = new Int32Array(this._bufferSize);
-
-            // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+            this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
 
             if (use_base_vertex_base_instance) {
                 // actually only use base vertex
@@ -314,11 +268,12 @@ WebGLStage = Utilities.createSubclass(Stage,
 
                 for (let i = 0; i < this._bufferSize; ++i) {
                     this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
+
+                    this._multi_draw_offsets[i] = i * 2 * 3;
                 }
 
-                this._multi_draw_offsets.fill(0);
+                // this._multi_draw_offsets.fill(0);
             } else {
-                // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
                 for (let i = 0; i < this._bufferSize; ++i) {
                     // this._multi_draw_firsts[i] = i * 3;
 
@@ -331,36 +286,6 @@ WebGLStage = Utilities.createSubclass(Stage,
             
             // Currently all our testing geometries are triangles. But they don't have to be
             this._multi_draw_counts.fill(3);
-
-            // if (use_multi_draw || use_attributes) {
-                
-            //     if (!use_base_vertex_base_instance) {
-            //         // indexData = new Uint16Array(this._bufferSize * this._indexData.length);
-            //         this._currentIndexData = new Uint16Array(this._bufferSize * this._indexData.length);
-            //         this._originalIndexData = indexData;
-                    
-            //         // Indices data here are added with extra offset
-            //         // They need no update after setup
-            //         for (let i = 0; i < this._bufferSize; ++i) {
-            //             // indexData.set(this._indexData, i * this._indexData.length);
-            //             let o = i * 3;  // assume this._indexData.length = 3;
-            //             indexData[o] = this._indexData[0] + o;
-            //             indexData[o + 1] = this._indexData[1] + o;
-            //             indexData[o + 2] = this._indexData[2] + o;
-            //         }
-            //     }
-            //     else
-            //     {
-            //         // // This is temporary usage which assume all primitives having same indexData (triangle)
-            //         // indexData = this._indexData;
-
-            //         // Directly copy the original indexData into indexBuffer
-            //         for (let i = 0; i < this._bufferSize; ++i) {
-            //             indexData.set(this._indexData, i * this._indexData.length);
-            //         }
-            //     }
-
-            // }
 
             if (!use_base_vertex_base_instance) {
                 // indexData = new Uint16Array(this._bufferSize * this._indexData.length);
@@ -389,7 +314,7 @@ WebGLStage = Utilities.createSubclass(Stage,
                 }
             }
 
-            console.log(this._bufferSize);
+            // console.log(this._bufferSize);
 
             if (use_ubos) {
                 this._transformData = new Float32Array(this._bufferSize * 8);
@@ -407,11 +332,11 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._transformData[i * 8 + 4] = scalarOffset;
                 }
 
-                console.log(this._transformData[1000 * 8 + 0]);
-                console.log(this._transformData[1000 * 8 + 1]);
-                console.log(this._transformData[1000 * 8 + 2]);
-                console.log(this._transformData[1000 * 8 + 3]);
-                console.log(this._transformData[1000 * 8 + 4]);
+                // console.log(this._transformData[1000 * 8 + 0]);
+                // console.log(this._transformData[1000 * 8 + 1]);
+                // console.log(this._transformData[1000 * 8 + 2]);
+                // console.log(this._transformData[1000 * 8 + 3]);
+                // console.log(this._transformData[1000 * 8 + 4]);
 
                 const uniformBufferCount = Math.ceil(this._bufferSize / this._maxUniformArraySize);
                 this._uniformBuffers = new Array(uniformBufferCount);
@@ -464,12 +389,12 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._uniformData[i * 6 + 5] = Stage.random(0, 10);
                 }
 
-                console.log(this._uniformData[1000 * 6 + 0]);
-                // console.log(this._uniformData[1000 * 6 + 1]);
-                console.log(this._uniformData[1000 * 6 + 2]);
-                console.log(this._uniformData[1000 * 6 + 3]);
-                console.log(this._uniformData[1000 * 6 + 4]);
-                console.log(this._uniformData[1000 * 6 + 5]);
+                // console.log(this._uniformData[1000 * 6 + 0]);
+                // // console.log(this._uniformData[1000 * 6 + 1]);
+                // console.log(this._uniformData[1000 * 6 + 2]);
+                // console.log(this._uniformData[1000 * 6 + 3]);
+                // console.log(this._uniformData[1000 * 6 + 4]);
+                // console.log(this._uniformData[1000 * 6 + 5]);
             }
 
             this._positionBuffer = gl.createBuffer();
@@ -487,17 +412,12 @@ WebGLStage = Utilities.createSubclass(Stage,
             gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, gl.DYNAMIC_DRAW);
             // gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, use_base_vertex_base_instance ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
 
-            // // Bind for draw
-            // gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
-            // gl.vertexAttribPointer(this._aPosition, 4, gl.FLOAT, false, 0, 0);
-
-            // gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
-            // gl.vertexAttribPointer(this._aColor, 4, gl.FLOAT, false, 0, 0);
-
-            // gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
-
 
             this._updateDrawList(gl);
+
+            // console.log(this._multi_draw_offsets);
+            // console.log(this._multi_draw_base_vertices);
+            // console.log('------------reset----------');
         },
 
         tune: function(count)
@@ -523,28 +443,24 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             gl.clear(gl.COLOR_BUFFER_BIT);
 
-            // this._updateDrawList(gl);
-
             this._drawListUpdateCountdown--;
-            // if (this._drawListUpdateCountdown > 0) {
-            //     return;
-            // } else {
             if (this._drawListUpdateCountdown <= 0) {
                 this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
                 this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
+
+                this._updateDrawList(gl);
             }
 
-            this._drawList = this._drawListSet[this._curDrawListId];
-            this._numDrawingObjects = this._drawList.length;
-
+            // this._drawList = this._drawListSet[this._curDrawListId];
+            // this._numDrawingObjects = this._drawList.length;
 
 
             if (!this._startTime)
                 this._startTime = Stage.dateCounterValue(1000);
             var elapsedTime = Stage.dateCounterValue(1000) - this._startTime;
 
-            // // tmp test static
-            // elapsedTime = 0;
+            // tmp test static
+            elapsedTime = 0;
 
             if (this._params.use_multi_draw) {
                 gl.uniform1f(this._uTime, elapsedTime);
@@ -561,23 +477,24 @@ WebGLStage = Utilities.createSubclass(Stage,
                                 gl.TRIANGLES,
                                 this._multi_draw_counts, chunk * this._maxUniformArraySize,
                                 gl.UNSIGNED_SHORT,
-                                this._multi_draw_offsets, chunk * this._maxUniformArraySize,
-                                // this._multi_draw_offsets_dynamic, chunk * this._maxUniformArraySize,
-                                this._multi_draw_instance_counts, 0,
+                                // this._multi_draw_offsets, chunk * this._maxUniformArraySize,
+                                this._multi_draw_offsets_dynamic, chunk * this._maxUniformArraySize,
+                                this._multi_draw_instance_counts, chunk * this._maxUniformArraySize,
                                 // this._multi_draw_base_vertices, 0,
-                                this._multi_draw_base_vertices_dynamic, 0,
-                                this._multi_draw_base_instances, 0,
+                                this._multi_draw_base_vertices_dynamic, chunk * this._maxUniformArraySize,
+                                this._multi_draw_base_instances, chunk * this._maxUniformArraySize,
                                 Math.min(this._maxUniformArraySize, remainingDrawCount));
                                 // 1);
-                            
-                            remainingDrawCount -= this._maxUniformArraySize;
+
+                                // console.log(this._multi_draw_offsets_dynamic[this._drawList[0]]);
+
+                            // remainingDrawCount -= this._maxUniformArraySize;
 
                             // this._multi_draw_base_vertex_base_instance.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
                             //     gl.TRIANGLES,
                             //     this._multi_draw_counts, chunk * this._maxUniformArraySize,
                             //     gl.UNSIGNED_SHORT,
                             //     this._multi_draw_offsets, chunk * this._maxUniformArraySize,
-                            //     // this._multi_draw_offsets_dynamic, chunk * this._maxUniformArraySize,
                             //     this._multi_draw_instance_counts, 0,
                             //     this._multi_draw_base_vertices, 0,
                             //     // this._multi_draw_base_vertices_dynamic, 0,
@@ -591,6 +508,8 @@ WebGLStage = Utilities.createSubclass(Stage,
                                 this._multi_draw_offsets, chunk * this._maxUniformArraySize,
                                 Math.min(this._maxUniformArraySize, remainingDrawCount));
                         }
+
+                        remainingDrawCount -= this._maxUniformArraySize;
                     }
                 } else {
                     this._multi_draw.multiDrawElementsWEBGL(
@@ -654,16 +573,6 @@ WebGLStage = Utilities.createSubclass(Stage,
 
         _updateDrawList: function(gl)
         {
-            // this._drawListUpdateCountdown--;
-            // if (this._drawListUpdateCountdown > 0) {
-            //     return;
-            // } else {
-            //     this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
-            // }
-
-            // this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
-
-            // // this._curDrawListId = 0;
 
             this._drawList = this._drawListSet[this._curDrawListId];
             this._numDrawingObjects = this._drawList.length;
@@ -673,9 +582,12 @@ WebGLStage = Utilities.createSubclass(Stage,
                 let id;
                 for (let i = 0; i < this._numDrawingObjects; i++) {
                     id = this._drawList[i];
-                    // this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
                     this._multi_draw_base_vertices_dynamic[i] = this._multi_draw_base_vertices[id];
+
+                    this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
                 }
+                // console.log(this._multi_draw_offsets_dynamic[0]);
+                // console.log(this._multi_draw_base_vertices_dynamic[0]);
             }
             // update this._multi_draw_counts data etc.
             else if (this._params.use_multi_draw) {
@@ -683,7 +595,6 @@ WebGLStage = Utilities.createSubclass(Stage,
 
                 for (let i = 0; i < this._numDrawingObjects; i++) {
                     id = this._drawList[i]; // drawing object id
-                    // this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
                     // update index data and upload
                     let o = i * 3;
                     let oid = id * 3;   // assume triangle, offset of it's first index in originalIndexData
@@ -698,7 +609,12 @@ WebGLStage = Utilities.createSubclass(Stage,
             {
                 // not using multi_draw
                 // no need to update draw list data
+
+                // console.log(this._multi_draw_offsets[this._drawList[0]]);
             }
+
+            // console.log(this._drawList);
+            
         },
 
         complexity: function()

--- a/Animometer/tests/3d/resources/webgl-indexed-instanced.js
+++ b/Animometer/tests/3d/resources/webgl-indexed-instanced.js
@@ -19,7 +19,6 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._params = {
                 use_attributes: Boolean(params.get("use_attributes")),
                 use_ubos: Boolean(params.get("use_ubos")),
-                // use_index: Boolean(params.get("use_index")),
                 use_multi_draw: Boolean(params.get("use_multi_draw")),
                 use_base_vertex_base_instance: Boolean(params.get("use_base_vertex_base_instance")),
                 webgl_version: WebGL2Supported() ? (Number(params.get("webgl_version")) || 1) : 1,
@@ -32,7 +31,6 @@ WebGLStage = Utilities.createSubclass(Stage,
             }
             var gl = this._gl;
 
-            
             this._multi_draw = this._params.use_multi_draw && gl.getExtension("WEBGL_multi_draw");
             this._draw_base_vertex_base_instance = !this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
             this._multi_draw_base_vertex_base_instance = this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance");
@@ -64,8 +62,10 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             // storing object id (order in the index buffer) that needs rendering for current frame
             this._drawList = [];
-            this._drawListRatio = 0.5;
-            this._drawListUpdateFrameInterval = 20;
+            // this._drawListRatio = 0.5;
+            this._drawListUpdateFrameInterval = 50;
+            // this._drawListUpdateFrameInterval = 20;
+            // this._drawListUpdateFrameInterval = 10;
             // this._drawListUpdateFrameInterval = 5;
             this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
             this._numDrawingObjects = 0;
@@ -189,17 +189,21 @@ WebGLStage = Utilities.createSubclass(Stage,
                 // 6, 7, 8
             ]);
 
-            if (!use_attributes && !use_ubos) {
-                this._positionBuffer = gl.createBuffer();
-                gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
-                gl.bufferData(gl.ARRAY_BUFFER, this._positionData, gl.STATIC_DRAW);
+            // if (!use_attributes && !use_ubos) {
+            //     this._positionBuffer = gl.createBuffer();
+            //     gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
+            //     gl.bufferData(gl.ARRAY_BUFFER, this._positionData, gl.STATIC_DRAW);
 
-                this._colorBuffer = gl.createBuffer();
-                gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
-                gl.bufferData(gl.ARRAY_BUFFER, this._colorData, gl.STATIC_DRAW);
-            }
+            //     this._colorBuffer = gl.createBuffer();
+            //     gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
+            //     gl.bufferData(gl.ARRAY_BUFFER, this._colorData, gl.STATIC_DRAW);
 
-            this._resetIfNecessary();
+            //     this._indexBuffer = gl.createBuffer();
+            //     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
+            //     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this._indexData, gl.STATIC_DRAW);
+            // }
+
+            // this._resetIfNecessary();
         },
 
         _getFunctionSource: function(id)
@@ -219,126 +223,176 @@ WebGLStage = Utilities.createSubclass(Stage,
             while (this._numTriangles > this._bufferSize)
                 this._bufferSize *= 4;
 
-
-            this._drawListSet.push([...Array(this._numTriangles).keys()]);
-            this._drawListSet.push([0, 10, 20, 30]);
-            // this._drawListSet.push([...Array(this._numTriangles / 10).keys()]);
+            // this._drawListSet.push([...Array(this._numTriangles).keys()]);
+            this._drawListSet.push([0, 10, 20, 30]);    // all wrong
+            // this._drawListSet.push([10]);
+            // this._drawListSet.push([0,1,2,3,4,5,6,7,8,9,10]);    // mbvbi = raw, m has wrong shape(id offset)
+            // this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
             // this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
             // this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
-            
+            // console.log(this._drawListSet);
 
             var use_attributes = this._params.use_attributes;
             var use_ubos = this._params.use_ubos;
             var use_multi_draw = this._params.use_multi_draw;
             var use_base_vertex_base_instance = this._params.use_base_vertex_base_instance;
 
-            if (use_multi_draw || use_base_vertex_base_instance) {
-                // this._multi_draw_firsts = new Int32Array(this._bufferSize);
-                this._multi_draw_counts = new Int32Array(this._bufferSize);
-                this._multi_draw_offsets = new Int32Array(this._bufferSize);
+            var positionData = new Float32Array(this._bufferSize * this._positionData.length);
+            var colorData = new Float32Array(this._bufferSize * this._colorData.length);
+            var indexData = new Uint16Array(this._bufferSize * this._indexData.length);
 
-                // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+            for (let i = 0; i < this._bufferSize; ++i) {
+                // positionData.set(this._positionData, i * this._positionData.length);
 
-                if (use_base_vertex_base_instance) {
-                    // actually only use base vertex
-                    this._multi_draw_instance_counts = new Int32Array(this._bufferSize);
-                    this._multi_draw_instance_counts.fill(1);
-                    this._multi_draw_base_vertices = new Int32Array(this._bufferSize);
-                    this._multi_draw_base_vertices_dynamic = new Int32Array(this._bufferSize);
-                    // this._multi_draw_base_vertices.fill(0);
-                    this._multi_draw_base_instances = new Int32Array(this._bufferSize);
-                    this._multi_draw_base_instances.fill(0);
-
-                    for (var i = 0; i < this._bufferSize; ++i) {
-                        this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
-                    }
-
-                    this._multi_draw_offsets.fill(0);
-                } else {
-                    this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
-                    for (var i = 0; i < this._bufferSize; ++i) {
-                        // this._multi_draw_firsts[i] = i * 3;
-                        this._multi_draw_offsets[i] = i * 2 * 3;    // in bytes, for index buffer
-    
-                        // this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
-                    }
+                let offset = i * this._positionData.length;
+                for (let j = 0; j < this._positionData.length; j+=4) {
+                    // each position is vec4
+                    // creating trangles of (pseudo) random shapes
+                    let s = Stage.random(0.1, 2.0);
+                    positionData[offset + j] = this._positionData[j + 0] * s;
+                    positionData[offset + j + 1] = this._positionData[j + 1] * s;
+                    positionData[offset + j + 2] = this._positionData[j + 2];
+                    positionData[offset + j + 3] = this._positionData[j + 3];
                 }
+
+                colorData.set(this._colorData, i * this._colorData.length);
+                // indexData.set(this._indexData, i * this._indexData.length);
+            }
+
+            // if (use_multi_draw || use_base_vertex_base_instance) {
+            //     // this._multi_draw_firsts = new Int32Array(this._bufferSize);
+            //     this._multi_draw_counts = new Int32Array(this._bufferSize);
+            //     this._multi_draw_offsets = new Int32Array(this._bufferSize);
+
+            //     // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+
+            //     if (use_base_vertex_base_instance) {
+            //         // actually only use base vertex
+            //         this._multi_draw_instance_counts = new Int32Array(this._bufferSize);
+            //         this._multi_draw_instance_counts.fill(1);
+            //         this._multi_draw_base_vertices = new Int32Array(this._bufferSize);
+            //         this._multi_draw_base_vertices_dynamic = new Int32Array(this._bufferSize);
+            //         // this._multi_draw_base_vertices.fill(0);
+            //         this._multi_draw_base_instances = new Uint32Array(this._bufferSize);
+            //         this._multi_draw_base_instances.fill(0);
+
+            //         for (let i = 0; i < this._bufferSize; ++i) {
+            //             this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
+            //         }
+
+            //         this._multi_draw_offsets.fill(0);
+            //     } else {
+            //         this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+            //         for (let i = 0; i < this._bufferSize; ++i) {
+            //             // this._multi_draw_firsts[i] = i * 3;
+            //             this._multi_draw_offsets[i] = i * 2 * 3;    // in bytes, for index buffer
+    
+            //             // this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
+            //         }
+            //     }
 
                 
-                this._multi_draw_counts.fill(3);
+            //     this._multi_draw_counts.fill(3);
+            // }
+
+            // this._multi_draw_firsts = new Int32Array(this._bufferSize);
+            this._multi_draw_counts = new Int32Array(this._bufferSize);
+            this._multi_draw_offsets = new Int32Array(this._bufferSize);
+
+            // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+
+            if (use_base_vertex_base_instance) {
+                // actually only use base vertex
+                this._multi_draw_instance_counts = new Int32Array(this._bufferSize);
+                this._multi_draw_instance_counts.fill(1);
+                this._multi_draw_base_vertices = new Int32Array(this._bufferSize);
+                this._multi_draw_base_vertices_dynamic = new Int32Array(this._bufferSize);
+                // this._multi_draw_base_vertices.fill(0);
+                this._multi_draw_base_instances = new Uint32Array(this._bufferSize);
+                this._multi_draw_base_instances.fill(0);
+
+                for (let i = 0; i < this._bufferSize; ++i) {
+                    this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
+                }
+
+                this._multi_draw_offsets.fill(0);
+            } else {
+                // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+                for (let i = 0; i < this._bufferSize; ++i) {
+                    // this._multi_draw_firsts[i] = i * 3;
+
+                    // in bytes (UNSIGNED_SHORT), for index buffer
+                    this._multi_draw_offsets[i] = i * 2 * 3;
+
+                    // this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
+                }
             }
+            
+            // Currently all our testing geometries are triangles. But they don't have to be
+            this._multi_draw_counts.fill(3);
 
-            if (use_multi_draw || use_attributes) {
-                var positionData = new Float32Array(this._bufferSize * this._positionData.length);
-                var colorData = new Float32Array(this._bufferSize * this._colorData.length);
-                // var indexData;
-                var indexData = new Uint16Array(this._bufferSize * this._indexData.length);
-                if (!use_base_vertex_base_instance) {
-                    // indexData = new Uint16Array(this._bufferSize * this._indexData.length);
-                    this._currentIndexData = new Uint16Array(this._bufferSize * this._indexData.length);
-                    this._originalIndexData = indexData;
+            // if (use_multi_draw || use_attributes) {
+                
+            //     if (!use_base_vertex_base_instance) {
+            //         // indexData = new Uint16Array(this._bufferSize * this._indexData.length);
+            //         this._currentIndexData = new Uint16Array(this._bufferSize * this._indexData.length);
+            //         this._originalIndexData = indexData;
+                    
+            //         // Indices data here are added with extra offset
+            //         // They need no update after setup
+            //         for (let i = 0; i < this._bufferSize; ++i) {
+            //             // indexData.set(this._indexData, i * this._indexData.length);
+            //             let o = i * 3;  // assume this._indexData.length = 3;
+            //             indexData[o] = this._indexData[0] + o;
+            //             indexData[o + 1] = this._indexData[1] + o;
+            //             indexData[o + 2] = this._indexData[2] + o;
+            //         }
+            //     }
+            //     else
+            //     {
+            //         // // This is temporary usage which assume all primitives having same indexData (triangle)
+            //         // indexData = this._indexData;
 
-                    for (var i = 0; i < this._bufferSize; ++i) {
-                        // indexData.set(this._indexData, i * this._indexData.length);
-                        let o = i * 3;  // assume this._indexData.length = 3;
-                        indexData[o] = this._indexData[0] + o;
-                        indexData[o + 1] = this._indexData[1] + o;
-                        indexData[o + 2] = this._indexData[2] + o;
-                    }
-                }
-                else
-                {
-                    // // This is temporary usage which assume all primitives having same indexData (triangle)
-                    // indexData = this._indexData;
+            //         // Directly copy the original indexData into indexBuffer
+            //         for (let i = 0; i < this._bufferSize; ++i) {
+            //             indexData.set(this._indexData, i * this._indexData.length);
+            //         }
+            //     }
 
-                    for (var i = 0; i < this._bufferSize; ++i) {
-                        indexData.set(this._indexData, i * this._indexData.length);
-                    }
-                }
+            // }
 
-                for (var i = 0; i < this._bufferSize; ++i) {
-                    // positionData.set(this._positionData, i * this._positionData.length);
-
-                    var offset = i * this._positionData.length;
-                    for (var j = 0; j < this._positionData.length; j+=4) {
-                        // assume vec4 position
-                        // TODO expand random usage to all cases
-                        var s = Stage.random(0.1, 2.0);
-                        positionData[offset + j] = this._positionData[j + 0] * s;
-                        positionData[offset + j + 1] = this._positionData[j + 1] * s;
-                        positionData[offset + j + 2] = this._positionData[j + 2];
-                        positionData[offset + j + 3] = this._positionData[j + 3];
-                    }
-
-                    colorData.set(this._colorData, i * this._colorData.length);
+            if (!use_base_vertex_base_instance) {
+                // indexData = new Uint16Array(this._bufferSize * this._indexData.length);
+                this._currentIndexData = new Uint16Array(this._bufferSize * this._indexData.length);
+                this._originalIndexData = indexData;
+                
+                // Indices data here are added with extra offset
+                for (let i = 0; i < this._bufferSize; ++i) {
                     // indexData.set(this._indexData, i * this._indexData.length);
+                    
+                    let o = i * 3;  // assume this._indexData.length = 3;
+                    let indexOffset = 
+                    indexData[o] = this._indexData[0] + o;
+                    indexData[o + 1] = this._indexData[1] + o;
+                    indexData[o + 2] = this._indexData[2] + o;
                 }
-
-                this._positionBuffer = gl.createBuffer();
-                gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
-                gl.bufferData(gl.ARRAY_BUFFER, positionData, gl.STATIC_DRAW);
-
-                this._colorBuffer = gl.createBuffer();
-                gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
-                gl.bufferData(gl.ARRAY_BUFFER, colorData, gl.STATIC_DRAW);
-
-                this._indexBuffer = gl.createBuffer();
-                gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
-                gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, use_base_vertex_base_instance ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
-
-                // Bind for draw
-                gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
-                gl.vertexAttribPointer(this._aPosition, 4, gl.FLOAT, false, 0, 0);
-
-                gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
-                gl.vertexAttribPointer(this._aColor, 4, gl.FLOAT, false, 0, 0);
-
-                // gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
             }
+            else
+            {
+                // // This is temporary usage which assume all primitives having same indexData (triangle)
+                // indexData = this._indexData;
+
+                // Directly copy the original indexData into indexBuffer
+                for (let i = 0; i < this._bufferSize; ++i) {
+                    indexData.set(this._indexData, i * this._indexData.length);
+                }
+            }
+
+            console.log(this._bufferSize);
 
             if (use_ubos) {
                 this._transformData = new Float32Array(this._bufferSize * 8);
-                for (var i = 0; i < this._bufferSize; ++i) {
+                for (let i = 0; i < this._bufferSize; ++i) {
                     var scale = Stage.random(0.2, 0.4);
                     var offsetX = Stage.random(-0.9, 0.9);
                     var offsetY = Stage.random(-0.9, 0.9);
@@ -351,6 +405,12 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._transformData[i * 8 + 3] = scalar;
                     this._transformData[i * 8 + 4] = scalarOffset;
                 }
+
+                console.log(this._transformData[10 * 8 + 0]);
+                console.log(this._transformData[10 * 8 + 1]);
+                console.log(this._transformData[10 * 8 + 2]);
+                console.log(this._transformData[10 * 8 + 3]);
+                console.log(this._transformData[10 * 8 + 4]);
 
                 const uniformBufferCount = Math.ceil(this._bufferSize / this._maxUniformArraySize);
                 this._uniformBuffers = new Array(uniformBufferCount);
@@ -367,13 +427,13 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             } else if (use_attributes) {
                 this._transformData = new Float32Array(this._bufferSize * 5 * 3);
-                for (var i = 0; i < this._bufferSize; ++i) {
+                for (let i = 0; i < this._bufferSize; ++i) {
                     var scale = Stage.random(0.2, 0.4);
                     var offsetX = Stage.random(-0.9, 0.9);
                     var offsetY = Stage.random(-0.9, 0.9);
                     var scalar = Stage.random(0.5, 2);
                     var scalarOffset = Stage.random(0, 10);
-                    for (var j = 0; j < 3; ++j) {
+                    for (let j = 0; j < 3; ++j) {
                         this._transformData[i * 3 * 5 + j * 5 + 0] = scale;
                         this._transformData[i * 3 * 5 + j * 5 + 1] = offsetX;
                         this._transformData[i * 3 * 5 + j * 5 + 2] = offsetY;
@@ -394,7 +454,7 @@ WebGLStage = Utilities.createSubclass(Stage,
                 gl.vertexAttribPointer(this._aScalarOffset, 1, gl.FLOAT, false, 5 * 4, 4 * 4);
             } else {
                 this._uniformData = new Float32Array(this._bufferSize * 6);
-                for (var i = 0; i < this._bufferSize; ++i) {
+                for (let i = 0; i < this._bufferSize; ++i) {
                     this._uniformData[i * 6 + 0] = Stage.random(0.2, 0.4);
                     this._uniformData[i * 6 + 1] = 0;
                     this._uniformData[i * 6 + 2] = Stage.random(-0.9, 0.9);
@@ -402,14 +462,41 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._uniformData[i * 6 + 4] = Stage.random(0.5, 2);
                     this._uniformData[i * 6 + 5] = Stage.random(0, 10);
                 }
+
+                console.log(this._uniformData[10 * 6 + 0]);
+                // console.log(this._uniformData[10 * 6 + 1]);
+                console.log(this._uniformData[10 * 6 + 2]);
+                console.log(this._uniformData[10 * 6 + 3]);
+                console.log(this._uniformData[10 * 6 + 4]);
+                console.log(this._uniformData[10 * 6 + 5]);
             }
 
-            // Bind for draw
+            this._positionBuffer = gl.createBuffer();
             gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
+            gl.bufferData(gl.ARRAY_BUFFER, positionData, gl.STATIC_DRAW);
             gl.vertexAttribPointer(this._aPosition, 4, gl.FLOAT, false, 0, 0);
 
+            this._colorBuffer = gl.createBuffer();
             gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
+            gl.bufferData(gl.ARRAY_BUFFER, colorData, gl.STATIC_DRAW);
             gl.vertexAttribPointer(this._aColor, 4, gl.FLOAT, false, 0, 0);
+
+            this._indexBuffer = gl.createBuffer();
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
+            gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, gl.DYNAMIC_DRAW);
+            // gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, use_base_vertex_base_instance ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
+
+            // // Bind for draw
+            // gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
+            // gl.vertexAttribPointer(this._aPosition, 4, gl.FLOAT, false, 0, 0);
+
+            // gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
+            // gl.vertexAttribPointer(this._aColor, 4, gl.FLOAT, false, 0, 0);
+
+            // gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
+
+
+            // this._updateDrawList(gl);
         },
 
         tune: function(count)
@@ -431,9 +518,28 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             this._updateDrawList(gl);
 
+            // this._drawListUpdateCountdown--;
+            // // if (this._drawListUpdateCountdown > 0) {
+            // //     return;
+            // // } else {
+            // if (this._drawListUpdateCountdown <= 0) {
+            //     this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
+            //     this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
+
+            //     // this._curDrawListId = 0;
+            // }
+
+            // this._drawList = this._drawListSet[this._curDrawListId];
+            // this._numDrawingObjects = this._drawList.length;
+
+
+
             if (!this._startTime)
                 this._startTime = Stage.dateCounterValue(1000);
             var elapsedTime = Stage.dateCounterValue(1000) - this._startTime;
+
+            // tmp test static
+            elapsedTime = 0;
 
             if (this._params.use_multi_draw) {
                 gl.uniform1f(this._uTime, elapsedTime);
@@ -513,7 +619,7 @@ WebGLStage = Utilities.createSubclass(Stage,
                     }
                     
                 } else {
-                    for (var i = 0; i < this._numTriangles; ++i) {
+                    for (let i = 0; i < this._numTriangles; ++i) {
                         // drawList, drawElements
                         gl.drawArrays(gl.TRIANGLES, i * 3, 3);
                     }
@@ -521,11 +627,12 @@ WebGLStage = Utilities.createSubclass(Stage,
 
                 
             } else {
-                for (var i = 0; i < this._numTriangles; ++i) {
+                // for (let i = 0; i < this._numTriangles; ++i) {
+                for (let i = 0; i < this._numDrawingObjects; ++i) {
+                    let oid = this._drawList[i];
+                    this._uniformData[oid * 6 + 1] = elapsedTime;
 
-                    this._uniformData[i * 6 + 1] = elapsedTime;
-
-                    var uniformDataOffset = i * 6;
+                    var uniformDataOffset = oid * 6;
                     gl.uniform1f(this._uScale, this._uniformData[uniformDataOffset++]);
                     gl.uniform1f(this._uTime, this._uniformData[uniformDataOffset++]);
                     gl.uniform1f(this._uOffsetX, this._uniformData[uniformDataOffset++]);
@@ -533,7 +640,9 @@ WebGLStage = Utilities.createSubclass(Stage,
                     gl.uniform1f(this._uScalar, this._uniformData[uniformDataOffset++]);
                     gl.uniform1f(this._uScalarOffset, this._uniformData[uniformDataOffset++]);
 
-                    gl.drawArrays(gl.TRIANGLES, 0, 3);
+                    // gl.drawArrays(gl.TRIANGLES, 0, 3);
+                    // console.log("ffff");
+                    gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, this._multi_draw_offsets[oid]);
                 }
             }
         },
@@ -547,11 +656,9 @@ WebGLStage = Utilities.createSubclass(Stage,
                 this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
             }
 
-            // temp
-            // this._drawList = [0, 10, 20, 30, 40];
             this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
-            // this._curDrawListId = 0;
 
+            // this._curDrawListId = 0;
 
             this._drawList = this._drawListSet[this._curDrawListId];
             this._numDrawingObjects = this._drawList.length;
@@ -571,7 +678,7 @@ WebGLStage = Utilities.createSubclass(Stage,
 
                 for (let i = 0; i < this._numDrawingObjects; i++) {
                     id = this._drawList[i];
-                    this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
+                    // this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
                     // update index data and upload
                     let o = i * 3;
                     let oid = id * 3;
@@ -584,7 +691,8 @@ WebGLStage = Utilities.createSubclass(Stage,
             }
             else
             {
-
+                // not using multi_draw
+                // no need to update draw list data
             }
         },
 

--- a/Animometer/tests/3d/resources/webgl-indexed-instanced.js
+++ b/Animometer/tests/3d/resources/webgl-indexed-instanced.js
@@ -63,9 +63,9 @@ WebGLStage = Utilities.createSubclass(Stage,
             // storing object id (order in the index buffer) that needs rendering for current frame
             this._drawList = [];
             // this._drawListRatio = 0.5;
-            this._drawListUpdateFrameInterval = 50;
+            // this._drawListUpdateFrameInterval = 50;
             // this._drawListUpdateFrameInterval = 20;
-            // this._drawListUpdateFrameInterval = 10;
+            this._drawListUpdateFrameInterval = 10;
             // this._drawListUpdateFrameInterval = 5;
             this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
             this._numDrawingObjects = 0;
@@ -223,13 +223,14 @@ WebGLStage = Utilities.createSubclass(Stage,
             while (this._numTriangles > this._bufferSize)
                 this._bufferSize *= 4;
 
-            // this._drawListSet.push([...Array(this._numTriangles).keys()]);
-            this._drawListSet.push([0, 10, 20, 30]);    // all wrong
+            this._drawListSet.push([...Array(this._numTriangles).keys()]);
+            this._drawListSet.push([0, 10, 20, 30, 1000]);    // all wrong (except 0)
+            // this._drawListSet.push([0]);
             // this._drawListSet.push([10]);
             // this._drawListSet.push([0,1,2,3,4,5,6,7,8,9,10]);    // mbvbi = raw, m has wrong shape(id offset)
-            // this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
-            // this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
-            // this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
+            this._drawListSet.push([...Array(this._numTriangles / 4).keys()]);
+            this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
+            this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
             // console.log(this._drawListSet);
 
             var use_attributes = this._params.use_attributes;
@@ -371,7 +372,7 @@ WebGLStage = Utilities.createSubclass(Stage,
                     // indexData.set(this._indexData, i * this._indexData.length);
                     
                     let o = i * 3;  // assume this._indexData.length = 3;
-                    let indexOffset = 
+                    // let indexOffset = this._draw;
                     indexData[o] = this._indexData[0] + o;
                     indexData[o + 1] = this._indexData[1] + o;
                     indexData[o + 2] = this._indexData[2] + o;
@@ -406,11 +407,11 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._transformData[i * 8 + 4] = scalarOffset;
                 }
 
-                console.log(this._transformData[10 * 8 + 0]);
-                console.log(this._transformData[10 * 8 + 1]);
-                console.log(this._transformData[10 * 8 + 2]);
-                console.log(this._transformData[10 * 8 + 3]);
-                console.log(this._transformData[10 * 8 + 4]);
+                console.log(this._transformData[1000 * 8 + 0]);
+                console.log(this._transformData[1000 * 8 + 1]);
+                console.log(this._transformData[1000 * 8 + 2]);
+                console.log(this._transformData[1000 * 8 + 3]);
+                console.log(this._transformData[1000 * 8 + 4]);
 
                 const uniformBufferCount = Math.ceil(this._bufferSize / this._maxUniformArraySize);
                 this._uniformBuffers = new Array(uniformBufferCount);
@@ -463,12 +464,12 @@ WebGLStage = Utilities.createSubclass(Stage,
                     this._uniformData[i * 6 + 5] = Stage.random(0, 10);
                 }
 
-                console.log(this._uniformData[10 * 6 + 0]);
-                // console.log(this._uniformData[10 * 6 + 1]);
-                console.log(this._uniformData[10 * 6 + 2]);
-                console.log(this._uniformData[10 * 6 + 3]);
-                console.log(this._uniformData[10 * 6 + 4]);
-                console.log(this._uniformData[10 * 6 + 5]);
+                console.log(this._uniformData[1000 * 6 + 0]);
+                // console.log(this._uniformData[1000 * 6 + 1]);
+                console.log(this._uniformData[1000 * 6 + 2]);
+                console.log(this._uniformData[1000 * 6 + 3]);
+                console.log(this._uniformData[1000 * 6 + 4]);
+                console.log(this._uniformData[1000 * 6 + 5]);
             }
 
             this._positionBuffer = gl.createBuffer();
@@ -496,7 +497,7 @@ WebGLStage = Utilities.createSubclass(Stage,
             // gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
 
 
-            // this._updateDrawList(gl);
+            this._updateDrawList(gl);
         },
 
         tune: function(count)
@@ -510,27 +511,31 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._resetIfNecessary();
         },
 
+        // _updateCurrentIndexData: function()
+        // {
+        //     // used by multi draw without base vertex base instance option
+
+        // },
+
         animate: function(timeDelta)
         {
             var gl = this._gl;
 
             gl.clear(gl.COLOR_BUFFER_BIT);
 
-            this._updateDrawList(gl);
+            // this._updateDrawList(gl);
 
-            // this._drawListUpdateCountdown--;
-            // // if (this._drawListUpdateCountdown > 0) {
-            // //     return;
-            // // } else {
-            // if (this._drawListUpdateCountdown <= 0) {
-            //     this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
-            //     this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
+            this._drawListUpdateCountdown--;
+            // if (this._drawListUpdateCountdown > 0) {
+            //     return;
+            // } else {
+            if (this._drawListUpdateCountdown <= 0) {
+                this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
+                this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
+            }
 
-            //     // this._curDrawListId = 0;
-            // }
-
-            // this._drawList = this._drawListSet[this._curDrawListId];
-            // this._numDrawingObjects = this._drawList.length;
+            this._drawList = this._drawListSet[this._curDrawListId];
+            this._numDrawingObjects = this._drawList.length;
 
 
 
@@ -538,8 +543,8 @@ WebGLStage = Utilities.createSubclass(Stage,
                 this._startTime = Stage.dateCounterValue(1000);
             var elapsedTime = Stage.dateCounterValue(1000) - this._startTime;
 
-            // tmp test static
-            elapsedTime = 0;
+            // // tmp test static
+            // elapsedTime = 0;
 
             if (this._params.use_multi_draw) {
                 gl.uniform1f(this._uTime, elapsedTime);
@@ -649,16 +654,16 @@ WebGLStage = Utilities.createSubclass(Stage,
 
         _updateDrawList: function(gl)
         {
-            this._drawListUpdateCountdown--;
-            if (this._drawListUpdateCountdown > 0) {
-                return;
-            } else {
-                this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
-            }
+            // this._drawListUpdateCountdown--;
+            // if (this._drawListUpdateCountdown > 0) {
+            //     return;
+            // } else {
+            //     this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
+            // }
 
-            this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
+            // this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
 
-            // this._curDrawListId = 0;
+            // // this._curDrawListId = 0;
 
             this._drawList = this._drawListSet[this._curDrawListId];
             this._numDrawingObjects = this._drawList.length;
@@ -677,15 +682,15 @@ WebGLStage = Utilities.createSubclass(Stage,
                 // this._multi_draw_counts; // currently all triangle reamin at 3    
 
                 for (let i = 0; i < this._numDrawingObjects; i++) {
-                    id = this._drawList[i];
+                    id = this._drawList[i]; // drawing object id
                     // this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
                     // update index data and upload
                     let o = i * 3;
-                    let oid = id * 3;
+                    let oid = id * 3;   // assume triangle, offset of it's first index in originalIndexData
                     //
-                    this._currentIndexData[o] = this._originalIndexData[oid] + oid;
-                    this._currentIndexData[o + 1] = this._originalIndexData[oid + 1] + oid;
-                    this._currentIndexData[o + 2] = this._originalIndexData[oid + 2] + oid;
+                    this._currentIndexData[o] = this._originalIndexData[oid];
+                    this._currentIndexData[o + 1] = this._originalIndexData[oid + 1];
+                    this._currentIndexData[o + 2] = this._originalIndexData[oid + 2];
                 }
                 gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0, this._currentIndexData, 0, this._numDrawingObjects * 3);
             }

--- a/Animometer/tests/3d/resources/webgl-indexed-instanced.js
+++ b/Animometer/tests/3d/resources/webgl-indexed-instanced.js
@@ -1,0 +1,609 @@
+(function() {
+
+function WebGL2Supported() {
+   return typeof WebGL2RenderingContext !== "undefined";
+}
+
+WebGLStage = Utilities.createSubclass(Stage,
+    function(element, options)
+    {
+        Stage.call(this);
+    },
+    {
+
+        initialize: function(benchmark, options)
+        {
+            Stage.prototype.initialize.call(this, benchmark, options);
+
+            var params = new URL(location.href).searchParams;
+            this._params = {
+                use_attributes: Boolean(params.get("use_attributes")),
+                use_ubos: Boolean(params.get("use_ubos")),
+                // use_index: Boolean(params.get("use_index")),
+                use_multi_draw: Boolean(params.get("use_multi_draw")),
+                use_base_vertex_base_instance: Boolean(params.get("use_base_vertex_base_instance")),
+                webgl_version: WebGL2Supported() ? (Number(params.get("webgl_version")) || 1) : 1,
+            };
+
+            if (this._params.webgl_version == 2) {
+                this._gl = this.element.getContext("webgl2");
+            } else {
+                this._gl = this.element.getContext("webgl");
+            }
+            var gl = this._gl;
+
+            
+            this._multi_draw = this._params.use_multi_draw && gl.getExtension("WEBGL_multi_draw");
+            this._draw_base_vertex_base_instance = !this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
+            this._multi_draw_base_vertex_base_instance = this._params.use_multi_draw && this._params.use_base_vertex_base_instance && gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance");
+            // if (this._params.use_base_vertex_base_instance && !this._multi_draw_base_vertex_base_instance) {
+            if ( this._params.use_base_vertex_base_instance && !(this._draw_base_vertex_base_instance || this._multi_draw_base_vertex_base_instance) ) {
+                console.warn("Disabling use_base_vertex_base_instance. Extension not available.");
+                this._params.use_base_vertex_base_instance = false;
+            }
+            if (this._params.use_multi_draw && !this._multi_draw) {
+                console.warn("Disabling use_multi_draw. Extension not available.");
+                this._params.use_multi_draw = false;
+            }
+            if (this._params.use_ubos && this._params.webgl_version !== 2) {
+                console.warn("Disabling use_ubos. webgl_version is not 2.");
+                this._params.use_ubos = false;
+            }
+            if (this._params.use_ubos && !this._params.use_multi_draw) {
+                console.warn("Disabling use_ubos. use_multi_draw not enabled.");
+                this._params.use_ubos = false;
+            }
+            if (this._params.use_multi_draw && !(this._params.use_ubos || this._params.use_attributes)) {
+                const flag = this._params.webgl_version == 2 ? "use_ubos" : "use_attributes";
+                console.warn("Defaulting to " + flag);
+                this._params[flag] = true;
+            }
+
+            this._numTriangles = 0;
+            this._bufferSize = 0;
+
+            // storing object id (order in the index buffer) that needs rendering for current frame
+            this._drawList = [];
+            this._drawListRatio = 0.5;
+            this._drawListUpdateFrameInterval = 20;
+            // this._drawListUpdateFrameInterval = 5;
+            this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
+            this._numDrawingObjects = 0;
+
+            // temp test
+            this._drawListSet = [];
+            this._curDrawListId = 0;
+            // this._drawListSet.push(Array())
+            // for (let i = 0; i < 5; i++) {
+            //     let list = [];
+            //     this._drawListSet[i] = list;
+            // }
+
+            var use_ubos = this._params.use_ubos;
+            var use_attributes = this._params.use_attributes;
+
+            gl.clearColor(0.5, 0.5, 0.5, 1);
+
+            // Create the vertex shader object.
+            var vertexShader = gl.createShader(gl.VERTEX_SHADER);
+
+            // The source code for the shader is extracted from the <script> element above.
+            if (use_ubos) {
+                let source = this._getFunctionSource("vertex-with-ubos");
+                this._maxUniformArraySize = Math.floor(
+                    gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE) /
+                    (8 * Float32Array.BYTES_PER_ELEMENT));
+                source = source.replace('MAX_ARRAY_SIZE', this._maxUniformArraySize);
+                gl.shaderSource(vertexShader, source);
+            } else if (use_attributes) {
+                gl.shaderSource(vertexShader, this._getFunctionSource("vertex-with-attributes"));
+            } else {
+                gl.shaderSource(vertexShader, this._getFunctionSource("vertex-with-uniforms"));
+            }
+
+            // Compile the shader.
+            gl.compileShader(vertexShader);
+            if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+                // We failed to compile. Output to the console and quit.
+                console.error("Vertex Shader failed to compile.");
+                console.error(gl.getShaderInfoLog(vertexShader));
+                return;
+            }
+
+            // Now do the fragment shader.
+            var fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+            if (use_ubos) {
+                gl.shaderSource(fragmentShader, this._getFunctionSource("fragment-300es"));
+            } else {
+                gl.shaderSource(fragmentShader, this._getFunctionSource("fragment"));
+            }
+            gl.compileShader(fragmentShader);
+            if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+                console.error("Fragment Shader failed to compile.");
+                console.error(gl.getShaderInfoLog(fragmentShader));
+                return;
+            }
+
+            // We have two compiled shaders. Time to make the program.
+            var program = gl.createProgram();
+            gl.attachShader(program, vertexShader);
+            gl.attachShader(program, fragmentShader);
+            gl.linkProgram(program);
+
+            if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+                console.error("Unable to link shaders into program.");
+                console.error(gl.getProgramInfoLog(program));
+                return;
+            }
+
+            // Our program has two inputs. We have a single uniform "color",
+            // and one vertex attribute "position".
+
+            gl.useProgram(program);
+            this._uTime = gl.getUniformLocation(program, "time");
+            if (use_ubos) {
+                const blockIndex = gl.getUniformBlockIndex(program, "DrawData");
+                gl.uniformBlockBinding(program, blockIndex, 0);
+            } else if (use_attributes) {
+                this._aScale = gl.getAttribLocation(program, "scale");
+                this._aOffsetX = gl.getAttribLocation(program, "offsetX");
+                this._aOffsetY = gl.getAttribLocation(program, "offsetY");
+                this._aScalar = gl.getAttribLocation(program, "scalar");
+                this._aScalarOffset = gl.getAttribLocation(program, "scalarOffset");
+
+                gl.enableVertexAttribArray(this._aScale);
+                gl.enableVertexAttribArray(this._aOffsetX);
+                gl.enableVertexAttribArray(this._aOffsetY);
+                gl.enableVertexAttribArray(this._aScalar);
+                gl.enableVertexAttribArray(this._aScalarOffset);
+            } else {
+                this._uScale = gl.getUniformLocation(program, "scale");
+                this._uOffsetX = gl.getUniformLocation(program, "offsetX");
+                this._uOffsetY = gl.getUniformLocation(program, "offsetY");
+                this._uScalar = gl.getUniformLocation(program, "scalar");
+                this._uScalarOffset = gl.getUniformLocation(program, "scalarOffset");
+            }
+
+            this._aPosition = gl.getAttribLocation(program, "position");
+            gl.enableVertexAttribArray(this._aPosition);
+
+            this._aColor = gl.getAttribLocation(program, "color");
+            gl.enableVertexAttribArray(this._aColor);
+
+            this._positionData = new Float32Array([
+                // x y z 1
+                   0,  0.1, 0, 1,
+                -0.1, -0.1, 0, 1,
+                 0.1, -0.1, 0, 1
+            ]);
+
+            this._colorData = new Float32Array([
+                1, 0, 0, 1,
+                0, 1, 0, 1,
+                0, 0, 1, 1
+            ]);
+
+            this._indexData = new Uint16Array([
+                0, 1, 2
+                // 3, 4, 5
+                // 6, 7, 8
+            ]);
+
+            if (!use_attributes && !use_ubos) {
+                this._positionBuffer = gl.createBuffer();
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
+                gl.bufferData(gl.ARRAY_BUFFER, this._positionData, gl.STATIC_DRAW);
+
+                this._colorBuffer = gl.createBuffer();
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
+                gl.bufferData(gl.ARRAY_BUFFER, this._colorData, gl.STATIC_DRAW);
+            }
+
+            this._resetIfNecessary();
+        },
+
+        _getFunctionSource: function(id)
+        {
+            return document.getElementById(id).text;
+        },
+
+        _resetIfNecessary: function()
+        {
+            var gl = this._gl;
+            if (this._numTriangles <= this._bufferSize)
+                return;
+
+            if (!this._bufferSize)
+                this._bufferSize = 128;
+
+            while (this._numTriangles > this._bufferSize)
+                this._bufferSize *= 4;
+
+
+            this._drawListSet.push([...Array(this._numTriangles).keys()]);
+            this._drawListSet.push([0, 10, 20, 30]);
+            // this._drawListSet.push([...Array(this._numTriangles / 10).keys()]);
+            // this._drawListSet.push([...Array(this._numTriangles / 2).keys()].map(x => x + 100));
+            // this._drawListSet.push([...Array(this._numTriangles / 8).keys()].map(x => x * 4));
+            
+
+            var use_attributes = this._params.use_attributes;
+            var use_ubos = this._params.use_ubos;
+            var use_multi_draw = this._params.use_multi_draw;
+            var use_base_vertex_base_instance = this._params.use_base_vertex_base_instance;
+
+            if (use_multi_draw || use_base_vertex_base_instance) {
+                // this._multi_draw_firsts = new Int32Array(this._bufferSize);
+                this._multi_draw_counts = new Int32Array(this._bufferSize);
+                this._multi_draw_offsets = new Int32Array(this._bufferSize);
+
+                // this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+
+                if (use_base_vertex_base_instance) {
+                    // actually only use base vertex
+                    this._multi_draw_instance_counts = new Int32Array(this._bufferSize);
+                    this._multi_draw_instance_counts.fill(1);
+                    this._multi_draw_base_vertices = new Int32Array(this._bufferSize);
+                    this._multi_draw_base_vertices_dynamic = new Int32Array(this._bufferSize);
+                    // this._multi_draw_base_vertices.fill(0);
+                    this._multi_draw_base_instances = new Int32Array(this._bufferSize);
+                    this._multi_draw_base_instances.fill(0);
+
+                    for (var i = 0; i < this._bufferSize; ++i) {
+                        this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
+                    }
+
+                    this._multi_draw_offsets.fill(0);
+                } else {
+                    this._multi_draw_offsets_dynamic = new Int32Array(this._bufferSize);
+                    for (var i = 0; i < this._bufferSize; ++i) {
+                        // this._multi_draw_firsts[i] = i * 3;
+                        this._multi_draw_offsets[i] = i * 2 * 3;    // in bytes, for index buffer
+    
+                        // this._multi_draw_base_vertices[i] = i * 3;  // all triangles, 3 vertices
+                    }
+                }
+
+                
+                this._multi_draw_counts.fill(3);
+            }
+
+            if (use_multi_draw || use_attributes) {
+                var positionData = new Float32Array(this._bufferSize * this._positionData.length);
+                var colorData = new Float32Array(this._bufferSize * this._colorData.length);
+                // var indexData;
+                var indexData = new Uint16Array(this._bufferSize * this._indexData.length);
+                if (!use_base_vertex_base_instance) {
+                    // indexData = new Uint16Array(this._bufferSize * this._indexData.length);
+                    this._currentIndexData = new Uint16Array(this._bufferSize * this._indexData.length);
+                    this._originalIndexData = indexData;
+
+                    for (var i = 0; i < this._bufferSize; ++i) {
+                        // indexData.set(this._indexData, i * this._indexData.length);
+                        let o = i * 3;  // assume this._indexData.length = 3;
+                        indexData[o] = this._indexData[0] + o;
+                        indexData[o + 1] = this._indexData[1] + o;
+                        indexData[o + 2] = this._indexData[2] + o;
+                    }
+                }
+                else
+                {
+                    // // This is temporary usage which assume all primitives having same indexData (triangle)
+                    // indexData = this._indexData;
+
+                    for (var i = 0; i < this._bufferSize; ++i) {
+                        indexData.set(this._indexData, i * this._indexData.length);
+                    }
+                }
+
+                for (var i = 0; i < this._bufferSize; ++i) {
+                    // positionData.set(this._positionData, i * this._positionData.length);
+
+                    var offset = i * this._positionData.length;
+                    for (var j = 0; j < this._positionData.length; j+=4) {
+                        // assume vec4 position
+                        // TODO expand random usage to all cases
+                        var s = Stage.random(0.1, 2.0);
+                        positionData[offset + j] = this._positionData[j + 0] * s;
+                        positionData[offset + j + 1] = this._positionData[j + 1] * s;
+                        positionData[offset + j + 2] = this._positionData[j + 2];
+                        positionData[offset + j + 3] = this._positionData[j + 3];
+                    }
+
+                    colorData.set(this._colorData, i * this._colorData.length);
+                    // indexData.set(this._indexData, i * this._indexData.length);
+                }
+
+                this._positionBuffer = gl.createBuffer();
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
+                gl.bufferData(gl.ARRAY_BUFFER, positionData, gl.STATIC_DRAW);
+
+                this._colorBuffer = gl.createBuffer();
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
+                gl.bufferData(gl.ARRAY_BUFFER, colorData, gl.STATIC_DRAW);
+
+                this._indexBuffer = gl.createBuffer();
+                gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
+                gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, use_base_vertex_base_instance ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
+
+                // Bind for draw
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
+                gl.vertexAttribPointer(this._aPosition, 4, gl.FLOAT, false, 0, 0);
+
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
+                gl.vertexAttribPointer(this._aColor, 4, gl.FLOAT, false, 0, 0);
+
+                // gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
+            }
+
+            if (use_ubos) {
+                this._transformData = new Float32Array(this._bufferSize * 8);
+                for (var i = 0; i < this._bufferSize; ++i) {
+                    var scale = Stage.random(0.2, 0.4);
+                    var offsetX = Stage.random(-0.9, 0.9);
+                    var offsetY = Stage.random(-0.9, 0.9);
+                    var scalar = Stage.random(0.5, 2);
+                    var scalarOffset = Stage.random(0, 10);
+
+                    this._transformData[i * 8 + 0] = scale;
+                    this._transformData[i * 8 + 1] = offsetX;
+                    this._transformData[i * 8 + 2] = offsetY;
+                    this._transformData[i * 8 + 3] = scalar;
+                    this._transformData[i * 8 + 4] = scalarOffset;
+                }
+
+                const uniformBufferCount = Math.ceil(this._bufferSize / this._maxUniformArraySize);
+                this._uniformBuffers = new Array(uniformBufferCount);
+                for (let i = 0; i < uniformBufferCount; ++i) {
+                    const buffer = gl.createBuffer();
+                    gl.bindBuffer(gl.UNIFORM_BUFFER, buffer);
+                    gl.bufferData(gl.UNIFORM_BUFFER, this._transformData.slice(
+                      this._maxUniformArraySize * 8 * i,
+                      this._maxUniformArraySize * 8 * (i + 1),
+                    ), gl.STATIC_DRAW);
+                    gl.bindBuffer(gl.UNIFORM_BUFFER, null);
+                    this._uniformBuffers[i] = buffer;
+                }
+
+            } else if (use_attributes) {
+                this._transformData = new Float32Array(this._bufferSize * 5 * 3);
+                for (var i = 0; i < this._bufferSize; ++i) {
+                    var scale = Stage.random(0.2, 0.4);
+                    var offsetX = Stage.random(-0.9, 0.9);
+                    var offsetY = Stage.random(-0.9, 0.9);
+                    var scalar = Stage.random(0.5, 2);
+                    var scalarOffset = Stage.random(0, 10);
+                    for (var j = 0; j < 3; ++j) {
+                        this._transformData[i * 3 * 5 + j * 5 + 0] = scale;
+                        this._transformData[i * 3 * 5 + j * 5 + 1] = offsetX;
+                        this._transformData[i * 3 * 5 + j * 5 + 2] = offsetY;
+                        this._transformData[i * 3 * 5 + j * 5 + 3] = scalar;
+                        this._transformData[i * 3 * 5 + j * 5 + 4] = scalarOffset;
+                    }
+                }
+
+                this._transformBuffer = gl.createBuffer();
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._transformBuffer);
+                gl.bufferData(gl.ARRAY_BUFFER, this._transformData, gl.STATIC_DRAW);
+
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._transformBuffer);
+                gl.vertexAttribPointer(this._aScale,        1, gl.FLOAT, false, 5 * 4, 0 * 4);
+                gl.vertexAttribPointer(this._aOffsetX,      1, gl.FLOAT, false, 5 * 4, 1 * 4);
+                gl.vertexAttribPointer(this._aOffsetY,      1, gl.FLOAT, false, 5 * 4, 2 * 4);
+                gl.vertexAttribPointer(this._aScalar,       1, gl.FLOAT, false, 5 * 4, 3 * 4);
+                gl.vertexAttribPointer(this._aScalarOffset, 1, gl.FLOAT, false, 5 * 4, 4 * 4);
+            } else {
+                this._uniformData = new Float32Array(this._bufferSize * 6);
+                for (var i = 0; i < this._bufferSize; ++i) {
+                    this._uniformData[i * 6 + 0] = Stage.random(0.2, 0.4);
+                    this._uniformData[i * 6 + 1] = 0;
+                    this._uniformData[i * 6 + 2] = Stage.random(-0.9, 0.9);
+                    this._uniformData[i * 6 + 3] = Stage.random(-0.9, 0.9);
+                    this._uniformData[i * 6 + 4] = Stage.random(0.5, 2);
+                    this._uniformData[i * 6 + 5] = Stage.random(0, 10);
+                }
+            }
+
+            // Bind for draw
+            gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
+            gl.vertexAttribPointer(this._aPosition, 4, gl.FLOAT, false, 0, 0);
+
+            gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
+            gl.vertexAttribPointer(this._aColor, 4, gl.FLOAT, false, 0, 0);
+        },
+
+        tune: function(count)
+        {
+            if (!count)
+                return;
+
+            this._numTriangles += count;
+            this._numTriangles = Math.max(this._numTriangles, 0);
+
+            this._resetIfNecessary();
+        },
+
+        animate: function(timeDelta)
+        {
+            var gl = this._gl;
+
+            gl.clear(gl.COLOR_BUFFER_BIT);
+
+            this._updateDrawList(gl);
+
+            if (!this._startTime)
+                this._startTime = Stage.dateCounterValue(1000);
+            var elapsedTime = Stage.dateCounterValue(1000) - this._startTime;
+
+            if (this._params.use_multi_draw) {
+                gl.uniform1f(this._uTime, elapsedTime);
+                if (this._params.use_ubos) {
+                    let remainingDrawCount = this._numDrawingObjects;
+
+                    // for (let chunk = 0; chunk < Math.ceil(this._numTriangles / this._maxUniformArraySize); chunk++) {
+                    for (let chunk = 0, count = Math.ceil(this._numDrawingObjects / this._maxUniformArraySize); chunk < count; chunk++) {
+                        
+                        gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, this._uniformBuffers[chunk]);
+                        
+                        if (this._params.use_base_vertex_base_instance) {
+                            this._multi_draw_base_vertex_base_instance.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+                                gl.TRIANGLES,
+                                this._multi_draw_counts, chunk * this._maxUniformArraySize,
+                                gl.UNSIGNED_SHORT,
+                                this._multi_draw_offsets, chunk * this._maxUniformArraySize,
+                                // this._multi_draw_offsets_dynamic, chunk * this._maxUniformArraySize,
+                                this._multi_draw_instance_counts, 0,
+                                // this._multi_draw_base_vertices, 0,
+                                this._multi_draw_base_vertices_dynamic, 0,
+                                this._multi_draw_base_instances, 0,
+                                Math.min(this._maxUniformArraySize, remainingDrawCount));
+                                // 1);
+                            
+                            remainingDrawCount -= this._maxUniformArraySize;
+
+                            // this._multi_draw_base_vertex_base_instance.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+                            //     gl.TRIANGLES,
+                            //     this._multi_draw_counts, chunk * this._maxUniformArraySize,
+                            //     gl.UNSIGNED_SHORT,
+                            //     this._multi_draw_offsets, chunk * this._maxUniformArraySize,
+                            //     // this._multi_draw_offsets_dynamic, chunk * this._maxUniformArraySize,
+                            //     this._multi_draw_instance_counts, 0,
+                            //     this._multi_draw_base_vertices, 0,
+                            //     // this._multi_draw_base_vertices_dynamic, 0,
+                            //     this._multi_draw_base_instances, 0,
+                            //     this._numDrawingObjects);
+                        } else {
+                            this._multi_draw.multiDrawElementsWEBGL(
+                                gl.TRIANGLES,
+                                this._multi_draw_counts, chunk * this._maxUniformArraySize,
+                                gl.UNSIGNED_SHORT,
+                                this._multi_draw_offsets, chunk * this._maxUniformArraySize,
+                                Math.min(this._maxUniformArraySize, remainingDrawCount));
+                        }
+                    }
+                } else {
+                    this._multi_draw.multiDrawElementsWEBGL(
+                        gl.TRIANGLES,
+                        this._multi_draw_counts, chunk * this._maxUniformArraySize,
+                        gl.UNSIGNED_SHORT,
+                        this._multi_draw_offsets, chunk * this._maxUniformArraySize,
+                        this._numTriangles);
+                    // this._multi_draw.multiDrawArraysWEBGL(
+                    //     gl.TRIANGLES,
+                    //     this._multi_draw_firsts, 0,
+                    //     this._multi_draw_counts, 0,
+                    //     this._numTriangles);
+                }
+            } else if (this._params.use_attributes) {
+                gl.uniform1f(this._uTime, elapsedTime);
+
+                if (this._params.use_base_vertex_base_instance) {
+                    for (let i = 0; i < this._numDrawingObjects; ++i) {
+                        let oid = this._drawList[i];
+                        this._draw_base_vertex_base_instance.drawElementsInstancedBaseVertexBaseInstanceWEBGL(
+                            gl.TRIANGLES,
+                            this._multi_draw_counts[oid],
+                            // 3,  // temp
+                            gl.UNSIGNED_SHORT,
+                            this._multi_draw_offsets[oid],
+                            1,
+                            this._multi_draw_base_vertices[oid],
+                            0
+                        );
+                    }
+                    
+                } else {
+                    for (var i = 0; i < this._numTriangles; ++i) {
+                        // drawList, drawElements
+                        gl.drawArrays(gl.TRIANGLES, i * 3, 3);
+                    }
+                }
+
+                
+            } else {
+                for (var i = 0; i < this._numTriangles; ++i) {
+
+                    this._uniformData[i * 6 + 1] = elapsedTime;
+
+                    var uniformDataOffset = i * 6;
+                    gl.uniform1f(this._uScale, this._uniformData[uniformDataOffset++]);
+                    gl.uniform1f(this._uTime, this._uniformData[uniformDataOffset++]);
+                    gl.uniform1f(this._uOffsetX, this._uniformData[uniformDataOffset++]);
+                    gl.uniform1f(this._uOffsetY, this._uniformData[uniformDataOffset++]);
+                    gl.uniform1f(this._uScalar, this._uniformData[uniformDataOffset++]);
+                    gl.uniform1f(this._uScalarOffset, this._uniformData[uniformDataOffset++]);
+
+                    gl.drawArrays(gl.TRIANGLES, 0, 3);
+                }
+            }
+        },
+
+        _updateDrawList: function(gl)
+        {
+            this._drawListUpdateCountdown--;
+            if (this._drawListUpdateCountdown > 0) {
+                return;
+            } else {
+                this._drawListUpdateCountdown = this._drawListUpdateFrameInterval;
+            }
+
+            // temp
+            // this._drawList = [0, 10, 20, 30, 40];
+            this._curDrawListId = (this._curDrawListId + 1) % this._drawListSet.length;
+            // this._curDrawListId = 0;
+
+
+            this._drawList = this._drawListSet[this._curDrawListId];
+            this._numDrawingObjects = this._drawList.length;
+
+
+            if (this._params.use_base_vertex_base_instance && this._params.use_multi_draw) {
+                let id;
+                for (let i = 0; i < this._numDrawingObjects; i++) {
+                    id = this._drawList[i];
+                    // this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
+                    this._multi_draw_base_vertices_dynamic[i] = this._multi_draw_base_vertices[id];
+                }
+            }
+            // update this._multi_draw_counts data etc.
+            else if (this._params.use_multi_draw) {
+                // this._multi_draw_counts; // currently all triangle reamin at 3    
+
+                for (let i = 0; i < this._numDrawingObjects; i++) {
+                    id = this._drawList[i];
+                    this._multi_draw_offsets_dynamic[i] = this._multi_draw_offsets[id];
+                    // update index data and upload
+                    let o = i * 3;
+                    let oid = id * 3;
+                    //
+                    this._currentIndexData[o] = this._originalIndexData[oid] + oid;
+                    this._currentIndexData[o + 1] = this._originalIndexData[oid + 1] + oid;
+                    this._currentIndexData[o + 2] = this._originalIndexData[oid + 2] + oid;
+                }
+                gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0, this._currentIndexData, 0, this._numDrawingObjects * 3);
+            }
+            else
+            {
+
+            }
+        },
+
+        complexity: function()
+        {
+            return this._numTriangles;
+        }
+    }
+);
+
+WebGLBenchmark = Utilities.createSubclass(Benchmark,
+    function(options)
+    {
+        Benchmark.call(this, new WebGLStage(), options);
+    }
+);
+
+window.benchmarkClass = WebGLBenchmark;
+
+})();
+
+

--- a/Animometer/tests/3d/webgl-indexed-instanced.html
+++ b/Animometer/tests/3d/webgl-indexed-instanced.html
@@ -161,7 +161,8 @@ void main() {
 var b = new WebGLStage;
 // b.initialize();
 // b.initialize(20000);
-b.initialize(80000);
+// b.initialize(80000);
+b.initialize(2048);
 // b.initialize(100);
 // b.tune(21850);
 // b.tune(21845);

--- a/Animometer/tests/3d/webgl-indexed-instanced.html
+++ b/Animometer/tests/3d/webgl-indexed-instanced.html
@@ -154,12 +154,14 @@ void main() {
     <script src="../../resources/statistics.js"></script>
     <script src="../resources/math.js"></script>
     <script src="../resources/main.js"></script>
-    <script src="resources/webgl.js"></script>
-    <!-- <script src="resources/webgl-o.js"></script> -->
+    <script src="resources/webgl-indexed-instanced.js"></script>
     <script>
 var b = new WebGLStage;
 b.initialize();
-b.tune(20000);
+// b.tune(20000);
+// b.tune(40000);
+b.tune(80000);
+// b.tune(2048);
 var lastTime = 0.0;
 function cb(timeStamp) {
   var timeDelta = 0.0;

--- a/Animometer/tests/3d/webgl-indexed-instanced.html
+++ b/Animometer/tests/3d/webgl-indexed-instanced.html
@@ -135,7 +135,6 @@ varying vec4 v_color;
 
 void main() {
     gl_FragColor = v_color;
-    //gl_FragColor = vec4(1, 1, 1, 1);
 }
     </script>
     <script id="fragment-300es" type="x-shader/x-glsl">#version 300 es
@@ -148,7 +147,6 @@ out vec4 FragColor;
 
 void main() {
     FragColor = v_color;
-    //FragColor = vec4(1, 1, 1, 1);
 }
     </script>
     <script src="../../resources/strings.js"></script>
@@ -159,21 +157,7 @@ void main() {
     <script src="resources/webgl-indexed-instanced.js"></script>
     <script>
 var b = new WebGLStage;
-// b.initialize();
-// b.initialize(20000);
-// b.initialize(80000);
-b.initialize(2048);
-// b.initialize(100);
-// b.tune(21850);
-// b.tune(21845);
-// b.tune(21847);
-// b.tune(21847);
-// b.tune(20000);
-// b.tune(40000);
-// b.tune(80000);
-// b.tune(1024);
-// b.tune(2048);
-// console.log(Pseudo._randomCalledTimes);
+b.initialize(20000);
 var lastTime = 0.0;
 function cb(timeStamp) {
   var timeDelta = 0.0;

--- a/Animometer/tests/3d/webgl-indexed-instanced.html
+++ b/Animometer/tests/3d/webgl-indexed-instanced.html
@@ -135,6 +135,7 @@ varying vec4 v_color;
 
 void main() {
     gl_FragColor = v_color;
+    //gl_FragColor = vec4(1, 1, 1, 1);
 }
     </script>
     <script id="fragment-300es" type="x-shader/x-glsl">#version 300 es
@@ -147,6 +148,7 @@ out vec4 FragColor;
 
 void main() {
     FragColor = v_color;
+    //FragColor = vec4(1, 1, 1, 1);
 }
     </script>
     <script src="../../resources/strings.js"></script>
@@ -157,11 +159,18 @@ void main() {
     <script src="resources/webgl-indexed-instanced.js"></script>
     <script>
 var b = new WebGLStage;
-b.initialize();
+// b.initialize();
+b.initialize(20000);
+// b.tune(21850);
+// b.tune(21845);
+// b.tune(21847);
+// b.tune(21847);
 // b.tune(20000);
 // b.tune(40000);
-b.tune(80000);
+// b.tune(80000);
+// b.tune(1024);
 // b.tune(2048);
+// console.log(Pseudo._randomCalledTimes);
 var lastTime = 0.0;
 function cb(timeStamp) {
   var timeDelta = 0.0;

--- a/Animometer/tests/3d/webgl-indexed-instanced.html
+++ b/Animometer/tests/3d/webgl-indexed-instanced.html
@@ -160,7 +160,9 @@ void main() {
     <script>
 var b = new WebGLStage;
 // b.initialize();
-b.initialize(20000);
+// b.initialize(20000);
+b.initialize(80000);
+// b.initialize(100);
 // b.tune(21850);
 // b.tune(21845);
 // b.tune(21847);

--- a/Animometer/tests/3d/webgl.html
+++ b/Animometer/tests/3d/webgl.html
@@ -155,7 +155,6 @@ void main() {
     <script src="../resources/math.js"></script>
     <script src="../resources/main.js"></script>
     <script src="resources/webgl.js"></script>
-    <!-- <script src="resources/webgl-o.js"></script> -->
     <script>
 var b = new WebGLStage;
 b.initialize();

--- a/README.md
+++ b/README.md
@@ -17,8 +17,43 @@ cd'd into <code>src</code>:
 ./tools/perf/run_benchmark --browser=release rendering.desktop --story=animometer_webgl &gt; output.txt
 </pre>
 
+The story names include:
+```
+animometer_webgl
+animometer_webgl_multi_draw
+animometer_webgl_indexed
+animometer_webgl_indexed_multi_draw
+animometer_webgl_indexed_multi_draw_base_vertex_base_instance
+```
+
 Look for the `frame_times` measurement in particular; that is a
 good indicator of how quickly and reliably the benchmark ran.
+
+# Running locally
+
+Launch an http server at the working directory and navigate the following url in your browser
+```
+http://localhost:8080/Animometer/tests/3d/webgl.html
+```
+or
+```
+http://localhost:8080/Animometer/tests/3d/webgl-indexed-instanced.html
+```
+
+Optional url args:
+
+```
+webgl_version
+use_ubos
+use_attributes
+use_multi_draw
+use_base_vertex_base_instance
+```
+
+Example:
+```
+http://localhost:8080/Animometer/tests/3d/webgl.html?webgl_version=2&use_ubos=1&use_multi_draw=1
+```
 
 # Re-recording the WPR
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,8 @@ archive in order to run the new version of the test. In this case,
 update the page set with the new URL, and run:
 
 <pre>
-./tools/perf/record_wpr --upload --browser=system rendering_desktop --story_filter=animometer_webgl
+./tools/perf/record_wpr --upload --browser=system rendering_desktop --story-filter=animometer_webgl
 </pre>
-
-<!-- <pre>
-./tools/perf/record_wpr --upload --browser=system tough_webgl_cases_page_set
-</pre> -->
 
 # Keeping the gh-pages branch up to date
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ update the page set with the new URL, and run:
 ./tools/perf/record_wpr --upload --browser=system rendering_desktop --story_filter=animometer_webgl
 </pre>
 
+<!-- <pre>
+./tools/perf/record_wpr --upload --browser=system tough_webgl_cases_page_set
+</pre> -->
+
 # Keeping the gh-pages branch up to date
 
 gh-pages in this repository exactly tracks master. To ensure this,


### PR DESCRIPTION
The new `webgl-indexed-instanced.html` basically has a big number of indexed geometries animating in the scene. There's a set of draw list containing a subset of these geometries that change between each frames. For drawElements and multiDrawElements, it needs to update the index data and upload to the element array buffer at each draw list update. For BaseVertex draw calls, we only need to update the args passed to the draw calls.

Docs with designs of test and perf graphs to come

Prefer a squash merge